### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A remote Model Context Protocol (MCP) server that provides access to Jina Reader, Embeddings and Reranker APIs with a suite of URL-to-markdown, web search, image search, and embeddings/reranker tools:
 
+<a href="https://glama.ai/mcp/servers/@jina-ai/MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jina-ai/MCP/badge" alt="Jina AI Remote Server MCP server" />
+</a>
+
 | Tool | Description | Is Jina API Key Required? |
 |-----------|-------------|----------------------|
 | `read_url` | Extract clean, structured content from web pages as markdown via [Reader API](https://jina.ai/reader) | Optional* |


### PR DESCRIPTION
This PR adds a badge for the [Jina AI Remote MCP Server](https://glama.ai/mcp/servers/@jina-ai/MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jina-ai/MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jina-ai/MCP/badge" alt="Jina AI Remote Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.