### PR TITLE
fix(bibtex): surface lookup failures instead of swallowing to empty

### DIFF
--- a/src/utils/bibtex.ts
+++ b/src/utils/bibtex.ts
@@ -159,8 +159,9 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 
 		return results;
 	} catch (error) {
-		// Timeout or network error
-		return [];
+		// Surface the failure instead of swallowing to [] (so a network/API error is not mistaken
+		// for "no matches"); searchBibtex decides whether it is fatal.
+		throw new Error(`DBLP: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
 
@@ -233,8 +234,7 @@ export async function searchSemanticScholar(args: BibtexSearchArgs): Promise<Bib
 
 		return results;
 	} catch (error) {
-		// Timeout or network error
-		return [];
+		throw new Error(`Semantic Scholar: ${error instanceof Error ? error.message : String(error)}`);
 	}
 }
 
@@ -345,16 +345,28 @@ function mergeEntries(target: BibtexEntry, source: BibtexEntry): void {
 export async function searchBibtex(args: BibtexSearchArgs): Promise<BibtexEntry[]> {
 	const { num = 10 } = args;
 
-	// Search both providers in parallel
-	const [dblpResults, s2Results] = await Promise.all([
+	// Search both providers in parallel. allSettled (not all) so one provider failing does not
+	// discard the other's results.
+	const settled = await Promise.allSettled([
 		searchDblp(args),
 		searchSemanticScholar(args),
 	]);
 
-	// Combine and deduplicate
-	const combined = [...dblpResults, ...s2Results];
-	const deduplicated = deduplicateResults(combined);
+	const combined: BibtexEntry[] = [];
+	const errors: string[] = [];
+	for (const r of settled) {
+		if (r.status === "fulfilled") combined.push(...r.value);
+		else errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason));
+	}
 
-	// Return requested number
-	return deduplicated.slice(0, num);
+	const deduplicated = deduplicateResults(combined);
+	const results = deduplicated.slice(0, num);
+
+	// A lookup that errored must not masquerade as "no matches": if every source we tried failed
+	// and we got nothing, surface the failure instead of returning an empty list.
+	if (results.length === 0 && errors.length > 0) {
+		throw new Error(`bibtex lookup failed (${errors.join("; ")})`);
+	}
+
+	return results;
 }


### PR DESCRIPTION
## Problem

`searchDblp` and `searchSemanticScholar` caught every error (timeout, network, API outage) and returned `[]`. A total provider outage was therefore indistinguishable from a genuine "no matches", and `search_bibtex` reported "No results found" on what was actually a failed lookup.

## Fix

- Each provider now `throw`s on error (prefixed with the source name).
- `searchBibtex` runs both via `Promise.allSettled`, so one provider failing still returns the other's hits.
- Only when **every** source failed and nothing was found does it throw `bibtex lookup failed (...)`. A real empty result (sources reachable, no hits) still returns `[]` and yields the friendly "No results found" message.
- The `search_bibtex` tool handler already wraps the call in try/catch and surfaces thrown errors via `createErrorResponse`, so the failure now reaches the client.

`npm run type-check` passes.