### PR TITLE
docs: add a live MCP health badge for the hosted server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [CLI version](https://github.com/jina-ai/cli)
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en/install-mcp?name=jina-mcp-server&config=eyJ1cmwiOiJodHRwczovL21jcC5qaW5hLmFpL3NzZSIsImhlYWRlcnMiOnsiQXV0aG9yaXphdGlvbiI6IkJlYXJlciBqaW5hXzhjMGM3YjUyNDI0ZjQxNmFiMDUzYTMxYzk2Mjc3NmI2VDBwNVR4eG52SUpXdFlvemhlRnZYVi16eUpoXyJ9fQ%3D%3D)
 [![Add MCP Server jina-mcp-server to LM Studio](https://files.lmstudio.ai/deeplink/mcp-install-light.svg)](https://lmstudio.ai/install-mcp?name=jina-mcp-server&config=eyJ1cmwiOiJodHRwczovL21jcC5qaW5hLmFpL3NzZSIsImhlYWRlcnMiOnsiQXV0aG9yaXphdGlvbiI6IkJlYXJlciBqaW5hXzI5NGQ5NmRiODFiYTQ1ZjY5MDFiOGM2OTRmM2I3NDU4ZVJMaV9MRS1xOGNqejRCeUE3REJ2cGZPUm5fdSJ9fQ%3D%3D)
+[![MCP status](https://mcpvitals.com/badge/186e8b59c9.svg)](https://mcpvitals.com/status/186e8b59c9)
 
 A remote Model Context Protocol (MCP) server that provides access to Jina Reader, Embeddings and Reranker APIs with a suite of URL-to-markdown, web search, image search, and embeddings/reranker tools:
 


### PR DESCRIPTION
Hi Jina team 👋

I run [MCP Vitals](https://mcpvitals.com), a health monitor for MCP servers. I set up a free public monitor for your hosted server (`mcp.jina.ai`) — it runs the real `initialize → tools/list` handshake every few minutes and currently sees it healthy with 21 tools.

This PR adds a small live status badge to the README so users can see at a glance that the server is up — and it surfaces downtime or tool-schema drift if that ever changes:

[![MCP status](https://mcpvitals.com/badge/186e8b59c9.svg)](https://mcpvitals.com/status/186e8b59c9)

- Free, nothing to sign up for; the badge links to a public uptime/latency page.
- If you'd rather own the monitor yourself, you can — it's a 2-minute setup.
- Not interested? Just close this, no worries at all.

Thanks for shipping such a solid remote MCP server 🙏
