### PR TITLE
fix: correctness and performance defects across tools and utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,10 @@ export default {
 			props.bearerToken = authHeader.substring(7);
 		}
 
+		// Remember whether the credential came from the caller, so tools that echo
+		// it back can tell it apart from the deployment fallback applied below.
+		props.bearerTokenFromRequest = Boolean(props.bearerToken);
+
 		// if no bearer token add a debug one from env
 		if (!props.bearerToken && env.JINA_API_KEY) {
 			props.bearerToken = env.JINA_API_KEY;
@@ -180,6 +184,22 @@ export default {
 
 		// API base URL for embedding/reranker endpoints (bypasses Cloudflare proxy issues)
 		props.apiBaseUrl = env.API_BASE_URL || 'https://api.jina.ai';
+
+		// Client identity for the response-size guardrail. This server is stateless -
+		// createMcpHandler gets no `storage`, so WorkerTransport never replays the
+		// `initialize` params into the per-request server and
+		// server.getClientVersion() is undefined during `tools/call`. Pass the
+		// transport User-Agent as a fallback hint, and let any client state its own
+		// budget explicitly with ?max_tokens= (0 disables truncation).
+		props.clientHint = request.headers.get("User-Agent") || undefined;
+
+		const maxTokensParam = url.searchParams.get("max_tokens");
+		if (maxTokensParam !== null) {
+			const parsed = Number.parseInt(maxTokensParam, 10);
+			if (Number.isFinite(parsed) && parsed >= 0) {
+				props.maxResponseTokens = parsed;
+			}
+		}
 
 		// Extract context information for the primer tool
 		const context: any = {};
@@ -286,7 +306,8 @@ export default {
 						exclude_tools: "Comma-separated tool names to exclude (e.g., search_web,search_arxiv)",
 						include_tools: "Comma-separated tool names to include",
 						exclude_tags: "Comma-separated tags to exclude (e.g., parallel,search)",
-						include_tags: "Comma-separated tags to include"
+						include_tags: "Comma-separated tags to include",
+						max_tokens: "Cap the size of read_url/parallel_read_url responses in tokens (0 disables truncation)"
 					},
 					tags: TOOL_TAGS,
 					examples: [

--- a/src/tools/jina-tools.ts
+++ b/src/tools/jina-tools.ts
@@ -22,9 +22,31 @@ import {
 } from "../utils/search.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+/**
+ * Guess the media type of a raw base64 image from its leading bytes.
+ *
+ * Caller-supplied base64 is passed through untouched, so labelling it
+ * "image/jpeg" (as this used to) mislabels every PNG/GIF/WebP the caller sends.
+ */
+function sniffBase64ImageMimeType(base64: string): string {
+	const head = base64.slice(0, 16);
+	if (head.startsWith('iVBORw0KGgo')) return 'image/png';
+	if (head.startsWith('R0lGOD')) return 'image/gif';
+	if (head.startsWith('UklGR')) return 'image/webp';
+	if (head.startsWith('PHN2Zy') || head.startsWith('PD94bW')) return 'image/svg+xml';
+	return 'image/jpeg';
+}
+
+const SCREENSHOT_TIMEOUT_MS = 60000;
+const SCREENSHOT_DOWNLOAD_TIMEOUT_MS = 20000;
+
 export function registerJinaTools(server: McpServer, getProps: () => any, enabledTools: Set<string> | null = null) {
 	// Helper to get client name for guardrail check
-	const getClientName = () => server.server.getClientVersion()?.name;
+	// getClientVersion() only has a value on the server instance that handled
+	// `initialize`; this deployment builds a fresh server per request, so it is
+	// undefined at tool-call time. props.clientHint (the transport User-Agent,
+	// set in index.ts) is the fallback that keeps the guardrail reachable.
+	const getClientName = () => server.server.getClientVersion()?.name ?? (getProps().clientHint as string | undefined);
 	// Helper function to create error responses
 	const createErrorResponse = (message: string) => ({
 		content: [{ type: "text" as const, text: message }],
@@ -41,12 +63,14 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			{},
 			async () => {
 				const props = getProps();
-				const token = props.bearerToken as string;
-				if (!token) {
+				// props.bearerToken is not necessarily the caller's own credential -
+				// index.ts falls back to the deployment's configured key. This tool
+				// exists to echo back what the caller sent, so gate on that.
+				if (!props.bearerTokenFromRequest) {
 					return createErrorResponse("No bearer token found in request");
 				}
 				return {
-					content: [{ type: "text" as const, text: token }],
+					content: [{ type: "text" as const, text: props.bearerToken as string }],
 				};
 			},
 		);
@@ -129,6 +153,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 
 					const response = await fetch('https://r.jina.ai/', {
 						method: 'POST',
+						signal: AbortSignal.timeout(SCREENSHOT_TIMEOUT_MS),
 						headers,
 						body: JSON.stringify({ url }),
 					});
@@ -139,8 +164,10 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 
 					const data = await response.json() as any;
 
-					// Get the screenshot URL from the response
-					const imageUrl = data.data.screenshotUrl || data.data.pageshotUrl;
+					// Get the screenshot URL from the response. An unexpected payload used
+					// to surface as "Cannot read properties of undefined" rather than
+					// anything a caller could act on.
+					const imageUrl = data?.data?.screenshotUrl || data?.data?.pageshotUrl;
 					if (!imageUrl) {
 						throw new Error("No screenshot URL received from API");
 					}
@@ -155,12 +182,18 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 							text: imageUrl,
 						});
 					} else {
-						// Download and process the image (resize to max 800px, convert to JPEG)
-						const processedResults = await downloadImages(imageUrl, 1, 10000);
+						// Download and process the image. A pageshot is a full-page capture
+						// (often 1280x20000); fitting that inside an 800x800 box left a
+						// ~51px-wide sliver in which nothing was legible. Constrain the
+						// width only and let the height follow.
+						const processedResults = await downloadImages(imageUrl, 1, SCREENSHOT_DOWNLOAD_TIMEOUT_MS, {
+							width: 1024,
+							height: firstScreenOnly === true ? 1024 : null,
+						});
 						const processedResult = processedResults[0];
 
-						if (!processedResult.success) {
-							throw new Error(`Failed to process screenshot: ${processedResult.error}`);
+						if (!processedResult?.success) {
+							throw new Error(`Failed to process screenshot: ${processedResult?.error ?? 'download timed out'}`);
 						}
 
 						contentItems.push({
@@ -186,7 +219,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"read_url",
 			"Extract and convert web page content to clean, readable markdown format. Perfect for reading articles, documentation, blog posts, or any web content. Use this when you need to analyze text content from websites, bypass paywalls, or get structured data.",
 			{
-				url: z.union([z.string().url(), z.array(z.string().url())]).describe("The complete URL of the webpage or PDF file to read and convert (e.g., 'https://example.com/article'). Can be a single URL string or an array of URLs for parallel reading."),
+				url: z.union([z.string().url(), z.array(z.string().url()).min(1).max(5)]).describe("The complete URL of the webpage or PDF file to read and convert (e.g., 'https://example.com/article'). Can be a single URL string or an array of up to 5 URLs for parallel reading."),
 				withAllLinks: z.boolean().optional().describe("Set to true to extract and return all hyperlinks found on the page as structured data"),
 				withAllImages: z.boolean().optional().describe("Set to true to extract and return all images found on the page as structured data")
 			},
@@ -213,7 +246,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 								type: "text" as const,
 								text: yamlStringify(result.structuredData),
 							}],
-						}, props.bearerToken, getClientName(), props.apiBaseUrl);
+						}, props.bearerToken, getClientName(), props.apiBaseUrl, props.maxResponseTokens);
 					}
 
 					// Handle multiple URLs with parallel reading
@@ -249,7 +282,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 
 						return applyTokenGuardrail({
 							content: contentItems,
-						}, props.bearerToken, getClientName(), props.apiBaseUrl);
+						}, props.bearerToken, getClientName(), props.apiBaseUrl, props.maxResponseTokens);
 					}
 
 					return createErrorResponse("Invalid URL format");
@@ -266,8 +299,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"search_web",
 			"Search the entire web for current information, news, articles, and websites. Use this when you need up-to-date information, want to find specific websites, research topics, or get the latest news. Ideal for answering questions about recent events, finding resources, or discovering relevant content.",
 			{
-				query: z.union([z.string(), z.array(z.string())]).describe("Search terms or keywords to find relevant web content (e.g., 'climate change news 2024', 'best pizza recipe'). Can be a single query string or an array of queries for parallel search."),
-				num: z.number().default(30).describe("Maximum number of search results to return, between 1-100"),
+				query: z.union([z.string(), z.array(z.string()).min(1).max(5)]).describe("Search terms or keywords to find relevant web content (e.g., 'climate change news 2024', 'best pizza recipe'). Can be a single query string or an array of up to 5 queries for parallel search."),
+				num: z.number().int().min(1).max(100).default(30).describe("Maximum number of search results to return, between 1-100"),
 				tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour, can be qdr:h, qdr:d, qdr:w, qdr:m, qdr:y"),
 				location: z.string().optional().describe("Location for search results, e.g., 'London', 'New York', 'Tokyo'"),
 				gl: z.string().optional().describe("Country code, e.g., 'dz' for Algeria"),
@@ -383,8 +416,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"search_arxiv",
 			"Search academic papers and preprints on arXiv repository. Perfect for finding research papers, scientific studies, technical papers, and academic literature. Use this when researching scientific topics, looking for papers by specific authors, or finding the latest research in fields like AI, physics, mathematics, computer science, etc.",
 			{
-				query: z.union([z.string(), z.array(z.string())]).describe("Academic search terms, author names, or research topics (e.g., 'transformer neural networks', 'Einstein relativity', 'machine learning optimization'). Can be a single query string or an array of queries for parallel search."),
-				num: z.number().default(30).describe("Maximum number of academic papers to return, between 1-100"),
+				query: z.union([z.string(), z.array(z.string()).min(1).max(5)]).describe("Academic search terms, author names, or research topics (e.g., 'transformer neural networks', 'Einstein relativity', 'machine learning optimization'). Can be a single query string or an array of up to 5 queries for parallel search."),
+				num: z.number().int().min(1).max(100).default(30).describe("Maximum number of academic papers to return, between 1-100"),
 				tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour, can be qdr:h, qdr:d, qdr:w, qdr:m, qdr:y")
 			},
 			async ({ query, num, tbs }: { query: string | string[]; num: number; tbs?: string }) => {
@@ -439,8 +472,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"search_ssrn",
 			"Search academic papers and preprints on SSRN (Social Science Research Network). Perfect for finding research papers in social sciences, economics, law, finance, accounting, management, and humanities. Use this when researching social science topics, looking for working papers, or finding the latest research in business and economics fields.",
 			{
-				query: z.union([z.string(), z.array(z.string())]).describe("Academic search terms, author names, or research topics (e.g., 'corporate governance', 'behavioral finance', 'contract law'). Can be a single query string or an array of queries for parallel search."),
-				num: z.number().default(30).describe("Maximum number of academic papers to return, between 1-100"),
+				query: z.union([z.string(), z.array(z.string()).min(1).max(5)]).describe("Academic search terms, author names, or research topics (e.g., 'corporate governance', 'behavioral finance', 'contract law'). Can be a single query string or an array of up to 5 queries for parallel search."),
+				num: z.number().int().min(1).max(100).default(30).describe("Maximum number of academic papers to return, between 1-100"),
 				tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour, can be qdr:h, qdr:d, qdr:w, qdr:m, qdr:y")
 			},
 			async ({ query, num, tbs }: { query: string | string[]; num: number; tbs?: string }) => {
@@ -495,8 +528,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"search_jina_blog",
 			"Search Jina AI news and blog posts at jina.ai/news for articles about AI, machine learning, neural search, embeddings, and Jina products. Use this to find official Jina documentation, tutorials, product announcements, and technical deep-dives.",
 			{
-				query: z.union([z.string(), z.array(z.string())]).describe("Search terms to find relevant Jina blog posts (e.g., 'embeddings', 'reranker', 'ColBERT'). Can be a single query string or an array of queries for parallel search."),
-				num: z.number().default(30).describe("Maximum number of blog posts to return, between 1-100"),
+				query: z.union([z.string(), z.array(z.string()).min(1).max(5)]).describe("Search terms to find relevant Jina blog posts (e.g., 'embeddings', 'reranker', 'ColBERT'). Can be a single query string or an array of up to 5 queries for parallel search."),
+				num: z.number().int().min(1).max(100).default(30).describe("Maximum number of blog posts to return, between 1-100"),
 				tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour, can be qdr:h, qdr:d, qdr:w, qdr:m, qdr:y")
 			},
 			async ({ query, num, tbs }: { query: string | string[]; num: number; tbs?: string }) => {
@@ -556,13 +589,14 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"Search for images across the web, similar to Google Images. Use this when you need to find photos, illustrations, diagrams, charts, logos, or any visual content. Perfect for finding images to illustrate concepts, locating specific pictures, or discovering visual resources. Images are returned by default as small base64-encoded JPEG images.",
 			{
 				query: z.string().describe("Image search terms describing what you want to find (e.g., 'sunset over mountains', 'vintage car illustration', 'data visualization chart')"),
+				num: z.number().int().min(1).max(30).default(10).describe("Maximum number of images to return (1-30, default: 10)"),
 				return_url: z.boolean().default(false).describe("Set to true to return image URLs, title, shapes, and other metadata. By default, images are downloaded as base64 and returned as rendered images."),
 				tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour, can be qdr:h, qdr:d, qdr:w, qdr:m, qdr:y"),
 				location: z.string().optional().describe("Location for search results, e.g., 'London', 'New York', 'Tokyo'"),
 				gl: z.string().optional().describe("Country code, e.g., 'dz' for Algeria"),
 				hl: z.string().optional().describe("Language code, e.g., 'zh-cn' for Simplified Chinese")
 			},
-			async ({ query, return_url, tbs, location, gl, hl }: SearchImageArgs) => {
+			async ({ query, num, return_url, tbs, location, gl, hl }: SearchImageArgs & { num: number }) => {
 				try {
 					const props = getProps();
 
@@ -577,7 +611,10 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 						return createErrorResponse(searchResult.error);
 					}
 
-					const data = { results: searchResult.results };
+					// The result set was previously used whole: every image the upstream
+					// returned was downloaded and inlined as base64, so a single call could
+					// push megabytes of image data into the model's context.
+					const data = { results: (searchResult.results || []).slice(0, num) };
 
 					// Prepare response content - always return as list structure for consistency
 					const contentItems: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [];
@@ -612,6 +649,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 						const downloadResults = await downloadImages(imageUrls, 3, 15000);
 
 						// Add successful downloads as images
+						const failures: string[] = [];
 						for (const result of downloadResults) {
 							if (result.success && result.data) {
 								contentItems.push({
@@ -619,10 +657,25 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 									data: result.data,
 									mimeType: result.mimeType,
 								});
+							} else {
+								failures.push(`${result.url}: ${result.error || 'unknown error'}`);
 							}
 						}
 
-
+						// Failures used to be dropped silently, so a query whose results were
+						// all SVG or all hotlink-protected returned an empty *successful*
+						// response - indistinguishable from "no images found".
+						if (contentItems.length === 0) {
+							return createErrorResponse(
+								`Found ${downloadResults.length} image(s) but none could be fetched:\n${failures.join('\n')}`
+							);
+						}
+						if (failures.length > 0) {
+							contentItems.push({
+								type: "text" as const,
+								text: `${failures.length} of ${downloadResults.length} image(s) could not be fetched:\n${failures.join('\n')}`,
+							});
+						}
 					}
 
 					return {
@@ -643,7 +696,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			{
 				searches: z.array(z.object({
 					query: z.string().describe("Search terms or keywords to find relevant web content"),
-					num: z.number().default(30).describe("Maximum number of search results to return, between 1-100"),
+					num: z.number().int().min(1).max(100).default(30).describe("Maximum number of search results to return, between 1-100"),
 					tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour"),
 					location: z.string().optional().describe("Location for search results, e.g., 'London', 'New York', 'Tokyo'"),
 					gl: z.string().optional().describe("Country code, e.g., 'dz' for Algeria"),
@@ -690,7 +743,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			{
 				searches: z.array(z.object({
 					query: z.string().describe("Academic search terms, author names, or research topics"),
-					num: z.number().default(30).describe("Maximum number of academic papers to return, between 1-100"),
+					num: z.number().int().min(1).max(100).default(30).describe("Maximum number of academic papers to return, between 1-100"),
 					tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour")
 				})).max(5).describe("Array of arXiv search configurations to execute in parallel (maximum 5 searches for optimal performance)"),
 				timeout: z.number().default(30000).describe("Timeout in milliseconds for all searches")
@@ -734,7 +787,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			{
 				searches: z.array(z.object({
 					query: z.string().describe("Academic search terms, author names, or research topics"),
-					num: z.number().default(30).describe("Maximum number of academic papers to return, between 1-100"),
+					num: z.number().int().min(1).max(100).default(30).describe("Maximum number of academic papers to return, between 1-100"),
 					tbs: z.string().optional().describe("Time-based search parameter, e.g., 'qdr:h' for past hour")
 				})).max(5).describe("Array of SSRN search configurations to execute in parallel (maximum 5 searches for optimal performance)"),
 				timeout: z.number().default(30000).describe("Timeout in milliseconds for all searches")
@@ -816,7 +869,7 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 
 					return applyTokenGuardrail({
 						content: contentItems,
-					}, props.bearerToken, getClientName(), props.apiBaseUrl);
+					}, props.bearerToken, getClientName(), props.apiBaseUrl, props.maxResponseTokens);
 				} catch (error) {
 					return createErrorResponse(`Error: ${error instanceof Error ? error.message : String(error)}`);
 				}
@@ -830,8 +883,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"classify_text",
 			"Classify texts into user-defined labels using Jina embeddings. Use this when you need to categorize, tag, or sort text content into predefined categories. Perfect for sentiment analysis, topic classification, content moderation, or any text categorization task.",
 			{
-				texts: z.array(z.string()).describe("Array of text strings to classify (e.g., ['I love this product', 'terrible experience'])"),
-				labels: z.array(z.string()).describe("Array of classification labels (e.g., ['positive', 'negative', 'neutral'])"),
+				texts: z.array(z.string()).min(1).max(1024).describe("Array of text strings to classify, up to 1024 (e.g., ['I love this product', 'terrible experience'])"),
+				labels: z.array(z.string()).min(2).max(256).describe("Array of classification labels (e.g., ['positive', 'negative', 'neutral'])"),
 				model: z.string().default("jina-embeddings-v5-text-small").describe("Model to use for classification (default: jina-embeddings-v5-text-small)")
 			},
 			async ({ texts, labels, model }: { texts: string[]; labels: string[]; model: string }) => {
@@ -899,8 +952,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"Rerank a list of documents by relevance to a query using Jina Reranker API. Use this when you have multiple documents and want to sort them by how well they match a specific query or topic. Perfect for document retrieval, content filtering, or finding the most relevant information from a collection.",
 			{
 				query: z.string().describe("The query or topic to rank documents against (e.g., 'machine learning algorithms', 'climate change solutions')"),
-				documents: z.array(z.string()).describe("Array of document texts to rerank by relevance"),
-				top_n: z.number().optional().describe("Maximum number of top results to return")
+				documents: z.array(z.string()).min(1).max(1024).describe("Array of document texts to rerank by relevance, up to 1024"),
+				top_n: z.number().int().min(1).optional().describe("Maximum number of top results to return")
 			},
 			async ({ query, documents, top_n }: { query: string; documents: string[]; top_n?: number }) => {
 				try {
@@ -964,8 +1017,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"deduplicate_strings",
 			"Get top-k semantically unique strings from a list using Jina embeddings and submodular optimization. Use this when you have many similar strings and want to select the most diverse subset that covers the semantic space. Perfect for removing duplicates, selecting representative samples, or finding diverse content.",
 			{
-				strings: z.array(z.string()).describe("Array of strings to deduplicate"),
-				k: z.number().optional().describe("Number of unique strings to return. If not provided, automatically finds optimal k by looking at diminishing return")
+				strings: z.array(z.string()).min(1).max(1000).describe("Array of strings to deduplicate, up to 1000"),
+				k: z.number().int().min(1).optional().describe("Number of unique strings to return. If not provided, automatically finds optimal k by looking at diminishing return")
 			},
 			async ({ strings, k }: { strings: string[]; k?: number }) => {
 				try {
@@ -1054,8 +1107,8 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 			"deduplicate_images",
 			"Get top-k semantically unique images (URLs or base64-encoded) using Jina CLIP v2 embeddings and submodular optimization. Use this when you have many visually similar images and want the most diverse subset.",
 			{
-				images: z.array(z.string()).describe("Array of image inputs to deduplicate. Each item can be either an HTTP(S) URL or a raw base64-encoded image string (without data URI prefix)."),
-				k: z.number().optional().describe("Number of unique images to return. If not provided, automatically finds optimal k by looking at diminishing return"),
+				images: z.array(z.string()).min(1).max(200).describe("Array of image inputs to deduplicate, up to 200. Each item can be either an HTTP(S) URL or a raw base64-encoded image string (without data URI prefix)."),
+				k: z.number().int().min(1).optional().describe("Number of unique images to return. If not provided, automatically finds optimal k by looking at diminishing return"),
 			},
 			async ({ images, k }: { images: string[]; k?: number }) => {
 				try {
@@ -1117,48 +1170,47 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 					// Get the selected images
 					const selectedImages = selectedIndices.map((idx) => ({ index: idx, source: images[idx] }));
 
+					const isUrl = (source: string) => /^https?:\/\//i.test(source);
 
 					// Use our consolidated downloadImages utility for consistency
-					const urlsToDownload = selectedImages
-						.filter(({ source }) => /^https?:\/\//i.test(source))
-						.map(({ source }) => source);
-
-					const base64Images = selectedImages
-						.filter(({ source }) => !/^https?:\/\//i.test(source))
-						.map(({ source }) => source);
+					const urlEntries = selectedImages.filter(({ source }) => isUrl(source));
+					const downloadResults = urlEntries.length > 0
+						? await downloadImages(urlEntries.map(({ source }) => source), 3, 15000)
+						: [];
 
 					const contentItems: Array<{ type: 'image'; data: string; mimeType: string } | { type: 'text'; text: string }> = [];
 
-					// Download URLs using our utility
-					if (urlsToDownload.length > 0) {
-						const downloadResults = await downloadImages(urlsToDownload, 3, 15000);
-
-						for (let i = 0; i < downloadResults.length; i++) {
-							const result = downloadResults[i];
-							const selectedImage = selectedImages.find(({ source }) => source === urlsToDownload[i]);
-
-							if (result.success && result.data) {
-								contentItems.push({
-									type: 'image' as const,
-									data: result.data,
-									mimeType: result.mimeType,
-								});
-							} else {
-								contentItems.push({
-									type: 'text' as const,
-									text: `Failed to download image at index ${selectedImage?.index || i}: ${result.error || 'Unknown error'}`,
-								});
-							}
+					// Emit in selection order (most-diverse first) rather than grouping
+					// all URLs ahead of all base64 inputs, and map each download back to
+					// its entry by position - looking it up by URL string resolved every
+					// duplicate URL to the first occurrence's index.
+					let urlPosition = 0;
+					for (const { index, source } of selectedImages) {
+						if (!isUrl(source)) {
+							contentItems.push({
+								type: 'image' as const,
+								data: source,
+								mimeType: sniffBase64ImageMimeType(source),
+							});
+							continue;
 						}
-					}
 
-					// Add base64 images directly
-					for (const base64Image of base64Images) {
-						contentItems.push({
-							type: 'image' as const,
-							data: base64Image,
-							mimeType: 'image/jpeg', // Our utility converts to JPEG
-						});
+						// downloadImages returns partial results when it hits its own
+						// timeout, so trailing entries can legitimately be missing
+						const result = downloadResults[urlPosition++];
+
+						if (result?.success && result.data) {
+							contentItems.push({
+								type: 'image' as const,
+								data: result.data,
+								mimeType: result.mimeType,
+							});
+						} else {
+							contentItems.push({
+								type: 'text' as const,
+								text: `Failed to download image at index ${index}: ${result?.error || 'Download timed out'}`,
+							});
+						}
 					}
 
 					if (contentItems.length === 0) {
@@ -1189,14 +1241,18 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 					// Import the utility function
 					const { searchBibtex } = await import("../utils/bibtex.js");
 
-					// Execute search
-					const results = await searchBibtex({ query, num, year, author });
+					// Execute search. `warnings` carries partial-coverage failures - one
+					// provider rate-limiting used to silently halve the results.
+					const warnings: string[] = [];
+					const results = await searchBibtex({ query, num, year, author }, warnings);
 
 					if (results.length === 0) {
 						return {
 							content: [{
 								type: "text" as const,
-								text: "No results found. Try different search terms or broader keywords."
+								text: warnings.length > 0
+									? `No results found (${warnings.join("; ")}). Try different search terms or broader keywords.`
+									: "No results found. Try different search terms or broader keywords."
 							}]
 						};
 					}
@@ -1216,7 +1272,9 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 					return {
 						content: [{
 							type: "text" as const,
-							text: yamlStringify({ results: formattedResults })
+							text: yamlStringify(warnings.length > 0
+								? { warnings, results: formattedResults }
+								: { results: formattedResults })
 						}]
 					};
 				} catch (error) {
@@ -1294,18 +1352,21 @@ export function registerJinaTools(server: McpServer, getProps: () => any, enable
 
 					// Limit floats to prevent large responses
 					const maxFloats = 20;
-					const totalFloats = data.floats.length;
-					const floatsToReturn = data.floats.slice(0, maxFloats);
+					const floats = Array.isArray(data?.floats) ? data.floats : [];
+					const totalFloats = floats.length;
+					const floatsToReturn = floats.slice(0, maxFloats);
 
 					// Return each float as an image with metadata
 					const contentItems: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [];
 
-					// Add summary metadata
+					// Add summary metadata. `floats`/`meta` are read defensively: an
+					// error-shaped 200 response used to throw a TypeError here and the
+					// caller only saw "Cannot read properties of undefined".
 					const summaryMeta: Record<string, any> = {
-						id: data.id,
-						num_floats: data.meta.num_floats,
-						num_pages: data.meta.num_pages,
-						latency_ms: data.meta.latency
+						id: data?.id,
+						num_floats: data?.meta?.num_floats ?? totalFloats,
+						num_pages: data?.meta?.num_pages,
+						latency_ms: data?.meta?.latency
 					};
 					if (totalFloats > maxFloats) {
 						summaryMeta.returned_floats = maxFloats;

--- a/src/utils/api-error-handler.ts
+++ b/src/utils/api-error-handler.ts
@@ -1,8 +1,38 @@
 /**
+ * Pull whatever explanation the API put in the error body.
+ *
+ * Without this the caller only ever saw the status line, so a 422 "input exceeds
+ * the maximum length" was indistinguishable from any other 422 and the model had
+ * nothing to act on. Bounded, and never throws.
+ */
+async function readErrorDetail(response: Response): Promise<string> {
+	try {
+		const body = (await response.text()).slice(0, 500).trim();
+		if (!body) return "";
+
+		try {
+			const parsed = JSON.parse(body) as Record<string, any>;
+			const detail =
+				parsed?.detail ??
+				parsed?.message ??
+				parsed?.error?.message ??
+				(typeof parsed?.error === "string" ? parsed.error : undefined);
+			if (detail) return typeof detail === "string" ? detail : JSON.stringify(detail);
+		} catch {
+			// not JSON, fall through to the raw body
+		}
+
+		return body;
+	} catch {
+		return "";
+	}
+}
+
+/**
  * Utility function to handle common API errors for Jina AI services
  * Returns a standardized error response object for MCP tools
  */
-export function handleApiError(response: Response, context: string = "API request") {
+export async function handleApiError(response: Response, context: string = "API request") {
 	if (response.status === 401) {
 		return {
 			content: [
@@ -39,11 +69,12 @@ export function handleApiError(response: Response, context: string = "API reques
 	}
 	
 	// Default error message for other HTTP errors
+	const detail = await readErrorDetail(response);
 	return {
 		content: [
 			{
 				type: "text" as const,
-				text: `Error: ${context} failed - ${response.status} ${response.statusText}`,
+				text: `Error: ${context} failed - ${response.status} ${response.statusText}${detail ? ` - ${detail}` : ""}`,
 			},
 		],
 		isError: true,

--- a/src/utils/bibtex.ts
+++ b/src/utils/bibtex.ts
@@ -26,26 +26,77 @@ export interface BibtexSearchArgs {
 	author?: string;
 }
 
-// Generate a citation key from title and year
-function generateKey(title: string, year?: number): string {
-	const words = title.toLowerCase().split(/\s+/);
-	const firstWord = words[0]?.replace(/[^a-z]/g, '') || 'unknown';
-	return `${firstWord}${year || ''}`;
+// DBLP returns scalars for most fields but switches to an array whenever a record
+// has several values (venue is commonly ["BIRDS+WEPIR@CHIIR", "CEUR Workshop
+// Proceedings"]). Those arrays used to flow straight into escapeBibtex, where
+// `.replace` is not a function - throwing out of the per-hit loop and discarding
+// the *entire* DBLP result set for the query.
+function asText(value: unknown): string {
+	if (value === null || value === undefined) return '';
+	if (Array.isArray(value)) return value.length > 0 ? asText(value[0]) : '';
+	return String(value);
+}
+
+function asOptionalText(value: unknown): string | undefined {
+	const text = asText(value);
+	return text === '' ? undefined : text;
+}
+
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+	amp: '&', lt: '<', gt: '>', quot: '"', apos: "'", nbsp: ' ',
+};
+
+/** DBLP serves HTML-escaped text; the entities must not reach the .bib output */
+function decodeHtmlEntities(text: string): string {
+	return text.replace(/&(#x[0-9a-f]+|#[0-9]+|[a-z]+);/gi, (match, entity: string) => {
+		if (entity.startsWith('#')) {
+			const code = entity[1] === 'x' || entity[1] === 'X'
+				? Number.parseInt(entity.slice(2), 16)
+				: Number.parseInt(entity.slice(1), 10);
+			return Number.isFinite(code) && code > 0 && code <= 0x10ffff ? String.fromCodePoint(code) : match;
+		}
+		return NAMED_HTML_ENTITIES[entity.toLowerCase()] ?? match;
+	});
+}
+
+// Generate a citation key from the first author's surname, year and first title
+// word. Keying on the title's first word alone collided constantly - every
+// "A Survey of ..." paper from the same year produced the same key.
+function generateKey(title: string, year?: number, authors: string[] = []): string {
+	const titleWord = title.toLowerCase().split(/\s+/)[0]?.replace(/[^a-z]/g, '') || 'unknown';
+	const surname = authors[0]?.trim().split(/\s+/).pop()?.toLowerCase().replace(/[^a-z]/g, '') || '';
+	return surname ? `${surname}${year || ''}${titleWord}` : `${titleWord}${year || ''}`;
+}
+
+// Escape special characters for BibTeX
+const BIBTEX_ESCAPES: Record<string, string> = {
+	'\\': '\\textbackslash{}',
+	'{': '\\{',
+	'}': '\\}',
+	'&': '\\&',
+	'%': '\\%',
+	'_': '\\_',
+	'$': '\\$',
+	'#': '\\#',
+	'~': '\\textasciitilde{}',
+	'^': '\\textasciicircum{}',
+};
+
+/**
+ * Escape in a single pass. The previous chained .replace() calls left `\`, `{`,
+ * `}`, `~` and `^` untouched, so an unbalanced brace from a source title swallowed
+ * the rest of the .bib file, and escaping `$` while leaving `\` alone turned real
+ * LaTeX titles such as "Fast $O(n\log n)$" into undefined control sequences.
+ */
+function escapeBibtex(value: unknown): string {
+	return asText(value).replace(/[\\{}&%_$#~^]/g, (ch) => BIBTEX_ESCAPES[ch] ?? ch);
 }
 
 // Format authors for BibTeX (Last, First and Last, First format)
 function formatAuthorsForBibtex(authors: string[]): string {
-	return authors.join(' and ');
-}
-
-// Escape special characters for BibTeX
-function escapeBibtex(str: string): string {
-	return str
-		.replace(/&/g, '\\&')
-		.replace(/%/g, '\\%')
-		.replace(/_/g, '\\_')
-		.replace(/\$/g, '\\$')
-		.replace(/#/g, '\\#');
+	// The author field used to be emitted raw, so "AT&T Labs Research" produced a
+	// misplaced alignment tab
+	return authors.map((author) => escapeBibtex(author)).join(' and ');
 }
 
 // Generate BibTeX string from entry data
@@ -72,7 +123,7 @@ function generateBibtexString(entry: Partial<BibtexEntry>): string {
 	}
 
 	const type = entry.type || 'misc';
-	const key = entry.key || generateKey(entry.title || 'unknown', entry.year);
+	const key = entry.key || generateKey(entry.title || 'unknown', entry.year, entry.authors);
 
 	return `@${type}{${key},\n${fields.join(',\n')}\n}`;
 }
@@ -90,7 +141,9 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 	const params = new URLSearchParams({
 		q: searchQuery,
 		format: 'json',
-		h: String(Math.min(num * 2, 100)), // Over-fetch for filtering
+		// The year filter is applied client-side below, so a num*2 window silently
+		// under-filled `num` whenever most hits predated `year`
+		h: String(year ? 100 : Math.min(num * 2, 100)), // Over-fetch for filtering
 	});
 
 	try {
@@ -99,8 +152,11 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 			signal: AbortSignal.timeout(5000),
 		});
 
+		// Returning [] here made a 429/5xx indistinguishable from "no matches" -
+		// the exact confusion the surface-lookup-failures change set out to remove,
+		// which only ever covered the `catch` path.
 		if (!response.ok) {
-			return [];
+			throw new Error(`HTTP ${response.status} ${response.statusText}`);
 		}
 
 		const data = await response.json() as any;
@@ -113,7 +169,7 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 			if (!info) continue;
 
 			// Apply year filter
-			const pubYear = info.year ? parseInt(info.year) : undefined;
+			const pubYear = info.year ? parseInt(asText(info.year)) : undefined;
 			if (year && pubYear && pubYear < year) continue;
 
 			// Parse authors
@@ -122,34 +178,38 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 				const authorList = Array.isArray(info.authors.author)
 					? info.authors.author
 					: [info.authors.author];
-				authors = authorList.map((a: any) => typeof a === 'string' ? a : a.text || a._);
+				authors = authorList
+					.map((a: any) => decodeHtmlEntities(asText(typeof a === 'string' ? a : a?.text ?? a?._)))
+					.filter((name: string) => name.length > 0);
 			}
 
 			// Determine entry type
 			let type: BibtexEntry['type'] = 'misc';
-			if (info.type === 'Conference and Workshop Papers') {
+			if (asText(info.type) === 'Conference and Workshop Papers') {
 				type = 'inproceedings';
-			} else if (info.type === 'Journal Articles') {
+			} else if (asText(info.type) === 'Journal Articles') {
 				type = 'article';
-			} else if (info.type === 'Books and Theses') {
+			} else if (asText(info.type) === 'Books and Theses') {
 				type = 'book';
 			}
 
+			// Every field is coerced through asText: DBLP returns arrays for records
+			// with multiple venues/volumes, which used to throw inside escapeBibtex
 			const entry: Partial<BibtexEntry> = {
 				type,
-				title: info.title?.replace(/\.$/, '') || '', // Remove trailing period
+				title: decodeHtmlEntities(asText(info.title).replace(/\.$/, '')), // Remove trailing period
 				authors,
 				year: pubYear,
-				venue: info.venue,
-				volume: info.volume,
-				number: info.number,
-				pages: info.pages,
-				doi: info.doi,
-				url: info.ee || info.url,
+				venue: asOptionalText(info.venue) && decodeHtmlEntities(asText(info.venue)),
+				volume: asOptionalText(info.volume),
+				number: asOptionalText(info.number),
+				pages: asOptionalText(info.pages),
+				doi: asOptionalText(info.doi),
+				url: asOptionalText(info.ee) ?? asOptionalText(info.url),
 				source: 'dblp',
 			};
 
-			entry.key = generateKey(entry.title!, entry.year);
+			entry.key = generateKey(entry.title!, entry.year, entry.authors);
 			entry.bibtex = generateBibtexString(entry);
 
 			results.push(entry as BibtexEntry);
@@ -167,10 +227,13 @@ export async function searchDblp(args: BibtexSearchArgs): Promise<BibtexEntry[]>
 
 // Search Semantic Scholar API
 export async function searchSemanticScholar(args: BibtexSearchArgs): Promise<BibtexEntry[]> {
-	const { query, num = 10, year } = args;
+	const { query, num = 10, year, author } = args;
 
 	const params = new URLSearchParams({
-		query,
+		// `author` was destructured out of existence here, so DBLP filtered by
+		// author and Semantic Scholar did not - half the merged result set ignored
+		// a filter the tool schema advertises
+		query: author ? `${query} ${author}` : query,
 		limit: String(Math.min(num * 2, 100)), // Over-fetch for filtering
 		fields: 'title,authors,year,venue,externalIds,abstract,citationCount,url',
 	});
@@ -186,7 +249,9 @@ export async function searchSemanticScholar(args: BibtexSearchArgs): Promise<Bib
 		});
 
 		if (!response.ok) {
-			return [];
+			// Unauthenticated Semantic Scholar routinely answers 429; returning []
+			// silently degraded search_bibtex to DBLP-only with no signal
+			throw new Error(`HTTP ${response.status} ${response.statusText}`);
 		}
 
 		const data = await response.json() as any;
@@ -224,7 +289,7 @@ export async function searchSemanticScholar(args: BibtexSearchArgs): Promise<Bib
 				source: 'semanticscholar',
 			};
 
-			entry.key = generateKey(entry.title!, entry.year);
+			entry.key = generateKey(entry.title!, entry.year, entry.authors);
 			entry.bibtex = generateBibtexString(entry);
 
 			results.push(entry as BibtexEntry);
@@ -261,61 +326,86 @@ function similarity(a: string, b: string): number {
 	return intersection / Math.max(wordsA.size, wordsB.size);
 }
 
-// Deduplicate results from multiple sources
+/**
+ * Deduplicate results from multiple sources.
+ *
+ * Survivors are held in a plain array keyed by object identity rather than in a
+ * Map keyed by `entry.key`. The old Map silently dropped distinct papers whenever
+ * two of them produced the same citation key, and it recorded DOIs/arXiv ids for
+ * entries that were subsequently merged away - leaving `seenDois` pointing at a
+ * key absent from the map, so the next matching DOI dereferenced `undefined` and
+ * threw out of the tool.
+ *
+ * Input order (each provider's own relevance ranking) is preserved; ordering for
+ * display is applied by the caller after the result set has been trimmed.
+ */
 export function deduplicateResults(results: BibtexEntry[]): BibtexEntry[] {
-	const seen = new Map<string, BibtexEntry>();
-	const seenDois = new Map<string, string>(); // doi -> key
-	const seenArxiv = new Map<string, string>(); // arxiv_id -> key
+	const kept: BibtexEntry[] = [];
+	const byDoi = new Map<string, BibtexEntry>();
+	const byArxiv = new Map<string, BibtexEntry>();
 
 	for (const entry of results) {
-		// Check DOI match
-		if (entry.doi) {
-			const normalizedDoi = normalizeDoi(entry.doi);
-			if (seenDois.has(normalizedDoi)) {
-				// Merge with existing entry (prefer one with more data)
-				const existingKey = seenDois.get(normalizedDoi)!;
-				const existing = seen.get(existingKey)!;
-				mergeEntries(existing, entry);
-				continue;
-			}
-			seenDois.set(normalizedDoi, entry.key);
+		const normalizedDoi = entry.doi ? normalizeDoi(entry.doi) : undefined;
+		const normalizedArxiv = entry.arxiv_id ? entry.arxiv_id.replace(/v\d+$/, '') : undefined; // Remove version
+
+		const existing =
+			(normalizedDoi ? byDoi.get(normalizedDoi) : undefined) ??
+			(normalizedArxiv ? byArxiv.get(normalizedArxiv) : undefined) ??
+			// Title similarity, for entries without DOI/arXiv
+			kept.find((candidate) => candidate.year === entry.year && similarity(entry.title, candidate.title) > 0.85);
+
+		if (existing) {
+			mergeEntries(existing, entry);
+			// Index the survivor under this entry's identifiers too, so a third
+			// record carrying either id still resolves to a live entry
+			if (normalizedDoi && !byDoi.has(normalizedDoi)) byDoi.set(normalizedDoi, existing);
+			if (normalizedArxiv && !byArxiv.has(normalizedArxiv)) byArxiv.set(normalizedArxiv, existing);
+			continue;
 		}
 
-		// Check arXiv ID match
-		if (entry.arxiv_id) {
-			const normalizedArxiv = entry.arxiv_id.replace(/v\d+$/, ''); // Remove version
-			if (seenArxiv.has(normalizedArxiv)) {
-				const existingKey = seenArxiv.get(normalizedArxiv)!;
-				const existing = seen.get(existingKey)!;
-				mergeEntries(existing, entry);
-				continue;
-			}
-			seenArxiv.set(normalizedArxiv, entry.key);
-		}
-
-		// Check title similarity (for entries without DOI/arXiv)
-		let isDuplicate = false;
-		for (const [key, existing] of seen) {
-			if (similarity(entry.title, existing.title) > 0.85 &&
-				entry.year === existing.year) {
-				mergeEntries(existing, entry);
-				isDuplicate = true;
-				break;
-			}
-		}
-
-		if (!isDuplicate) {
-			seen.set(entry.key, entry);
-		}
+		kept.push(entry);
+		if (normalizedDoi) byDoi.set(normalizedDoi, entry);
+		if (normalizedArxiv) byArxiv.set(normalizedArxiv, entry);
 	}
 
-	// Sort by year (descending) then title
-	return Array.from(seen.values()).sort((a, b) => {
-		if (a.year && b.year) {
-			if (a.year !== b.year) return b.year - a.year;
+	return kept;
+}
+
+/**
+ * Interleave the providers so the top `num` draws from both.
+ *
+ * `[...dblp, ...s2]` followed by a year-descending sort and slice() meant the
+ * returned set was "the newest of everything both APIs happened to return",
+ * discarding the relevance ranking the caller actually searched by.
+ */
+function interleaveBySource(lists: BibtexEntry[][]): BibtexEntry[] {
+	const merged: BibtexEntry[] = [];
+	const longest = Math.max(0, ...lists.map((list) => list.length));
+	for (let i = 0; i < longest; i++) {
+		for (const list of lists) {
+			if (i < list.length) merged.push(list[i]);
 		}
-		return a.title.localeCompare(b.title);
-	});
+	}
+	return merged;
+}
+
+/** Make citation keys unique within the returned set (smith2020attention, ...b, ...c) */
+function assignUniqueKeys(entries: BibtexEntry[]): void {
+	const used = new Set<string>();
+	for (const entry of entries) {
+		const base = entry.key;
+		let key = base;
+		let suffix = 0;
+		while (used.has(key)) {
+			key = `${base}${String.fromCharCode(97 + (suffix % 26))}`;
+			suffix++;
+		}
+		used.add(key);
+		if (key !== entry.key) {
+			entry.key = key;
+			entry.bibtex = generateBibtexString(entry);
+		}
+	}
 }
 
 // Merge two entries, keeping the most complete data
@@ -342,7 +432,7 @@ function mergeEntries(target: BibtexEntry, source: BibtexEntry): void {
 }
 
 // Main search function - searches both providers and deduplicates
-export async function searchBibtex(args: BibtexSearchArgs): Promise<BibtexEntry[]> {
+export async function searchBibtex(args: BibtexSearchArgs, warningsOut?: string[]): Promise<BibtexEntry[]> {
 	const { num = 10 } = args;
 
 	// Search both providers in parallel. allSettled (not all) so one provider failing does not
@@ -352,15 +442,21 @@ export async function searchBibtex(args: BibtexSearchArgs): Promise<BibtexEntry[
 		searchSemanticScholar(args),
 	]);
 
-	const combined: BibtexEntry[] = [];
+	const perSource: BibtexEntry[][] = [];
 	const errors: string[] = [];
 	for (const r of settled) {
-		if (r.status === "fulfilled") combined.push(...r.value);
+		if (r.status === "fulfilled") perSource.push(r.value);
 		else errors.push(r.reason instanceof Error ? r.reason.message : String(r.reason));
 	}
 
-	const deduplicated = deduplicateResults(combined);
-	const results = deduplicated.slice(0, num);
+	const deduplicated = deduplicateResults(interleaveBySource(perSource));
+	// Trim by relevance first, then order the survivors newest-first for display
+	const results = deduplicated.slice(0, num).sort((a, b) => {
+		if (a.year && b.year && a.year !== b.year) return b.year - a.year;
+		return a.title.localeCompare(b.title);
+	});
+
+	assignUniqueKeys(results);
 
 	// A lookup that errored must not masquerade as "no matches": if every source we tried failed
 	// and we got nothing, surface the failure instead of returning an empty list.
@@ -368,5 +464,20 @@ export async function searchBibtex(args: BibtexSearchArgs): Promise<BibtexEntry[
 		throw new Error(`bibtex lookup failed (${errors.join("; ")})`);
 	}
 
+	// A *partial* failure was previously invisible too: one provider down just
+	// halved the coverage with no signal to the caller.
+	if (warningsOut) {
+		for (const error of errors) warningsOut.push(`source unavailable: ${error}`);
+	}
+
 	return results;
+}
+
+/** Providers that failed, for callers that want to warn about partial coverage */
+export async function searchBibtexWithWarnings(
+	args: BibtexSearchArgs
+): Promise<{ results: BibtexEntry[]; warnings: string[] }> {
+	const warnings: string[] = [];
+	const results = await searchBibtex(args, warnings);
+	return { results, warnings };
 }

--- a/src/utils/guess-datetime.ts
+++ b/src/utils/guess-datetime.ts
@@ -1,8 +1,77 @@
 // Utility functions for guessing datetime from web pages
 // Refactored from Cloudflare Worker for MCP tool usage
 
+// The web predates neither of these, so anything outside the window is a parse
+// artifact rather than a publication date - a copyright range like "1999-2030",
+// an event scheduled for next year, a template placeholder, or a unix timestamp
+// read at the wrong scale. The upper bound keeps 48h of slack for clock skew and
+// for timezone-less strings that land "tomorrow" relative to UTC.
+const EARLIEST_PLAUSIBLE_PAGE_DATE = Date.UTC(1990, 0, 1);
+const FUTURE_TOLERANCE_MS = 48 * 60 * 60 * 1000;
+
+// Every extractor below runs its own regex passes over the whole document, so the
+// body has to be bounded: an unbounded response turns one tool call into an
+// unbounded amount of Worker CPU. Timestamps live in <head> and in feed preambles,
+// which comfortably fit these caps.
+const MAX_PAGE_BYTES = 2 * 1024 * 1024;
+const MAX_FEED_BYTES = 512 * 1024;
+const PAGE_FETCH_TIMEOUT_MS = 15000;
+const FEED_FETCH_TIMEOUT_MS = 5000;
+
+/** Read a response body as text, stopping after maxBytes */
+async function readCapped(response: Response, maxBytes: number): Promise<string> {
+    if (!response.body) return '';
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let text = '';
+    let total = 0;
+
+    try {
+        for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (!value) continue;
+
+            if (total + value.byteLength >= maxBytes) {
+                text += decoder.decode(value.subarray(0, maxBytes - total));
+                return text;
+            }
+
+            total += value.byteLength;
+            text += decoder.decode(value, { stream: true });
+        }
+        text += decoder.decode();
+    } finally {
+        await reader.cancel().catch(() => { });
+    }
+
+    return text;
+}
+
+function isPlausiblePageDate(date: Date | null): boolean {
+    if (!date) return false;
+    const t = date.getTime();
+    if (Number.isNaN(t)) return false;
+    return t >= EARLIEST_PLAUSIBLE_PAGE_DATE && t <= Date.now() + FUTURE_TOLERANCE_MS;
+}
+
+/** new Date(value), or null when it is unparseable or not a plausible page date */
+function toPlausibleDate(value: string | number): Date | null {
+    const date = new Date(value);
+    return isPlausiblePageDate(date) ? date : null;
+}
+
 // Improved parseDate function to handle more date formats
 function parseDate(dateStr: string): Date | null {
+    const parsed = parseDateUnfiltered(dateStr);
+    // A date the page cannot plausibly have been updated at is worse than no date:
+    // determineBestUpdateTime() picks the *most recent* candidate, so a single
+    // stray future date outranks every real signal on the page.
+    return isPlausiblePageDate(parsed) ? parsed : null;
+}
+
+function parseDateUnfiltered(dateStr: string): Date | null {
     if (!dateStr) return null;
 
     // Clean up the string (remove extra spaces, normalize separators)
@@ -255,8 +324,8 @@ function extractHtmlComments(html: string): Array<{
                 // Looks like a date but couldn't parse, try manual parsing
                 const parts = versionMatch[1].split(/[-\/]/);
                 if (parts.length === 3 && parts[0].length === 4) {
-                    const date = new Date(`${parts[0]}-${parts[1]}-${parts[2]}`);
-                    if (!isNaN(date.getTime())) {
+                    const date = toPlausibleDate(`${parts[0]}-${parts[1]}-${parts[2]}`);
+                    if (date) {
                         results.push({
                             type: 'htmlComment',
                             date: date.toISOString(),
@@ -318,7 +387,10 @@ function extractGitInfo(html: string): {
     }
 
     // Look for GitLab/GitHub deploy comments
-    const deployPattern = /<!--[\s\S]*?(?:deployed|deployment|deploy)[\s\S]*?((?:\d{4}-\d{2}-\d{2})|(?:\d{2}\/\d{2}\/\d{4}))[\\s\\S]*?-->/i;
+    // NB: the trailing class must be [\s\S] (any char). `[\\s\\S]` inside a regex
+    // *literal* is the three-character class {\, s, S}, which made this pattern
+    // match only when nothing but backslashes/s/S sat between the date and `-->`.
+    const deployPattern = /<!--[\s\S]*?(?:deployed|deployment|deploy)[\s\S]*?((?:\d{4}-\d{2}-\d{2})|(?:\d{2}\/\d{2}\/\d{4}))[\s\S]*?-->/i;
     const deployMatch = html.match(deployPattern);
 
     if (deployMatch) {
@@ -579,16 +651,16 @@ function extractJavaScriptTimestamps(html: string): Array<{
         for (const pattern of timestampPatterns) {
             const match = scriptContent.match(pattern);
             if (match && match[1]) {
-                let date;
+                let date: Date | null;
                 if (/^\d+$/.test(match[1])) {
                     // Handle Unix timestamps (in seconds or milliseconds)
                     const timestamp = parseInt(match[1]);
-                    date = new Date(timestamp > 9999999999 ? timestamp : timestamp * 1000);
+                    date = toPlausibleDate(timestamp > 9999999999 ? timestamp : timestamp * 1000);
                 } else {
-                    date = new Date(match[1]);
+                    date = toPlausibleDate(match[1]);
                 }
 
-                if (!isNaN(date.getTime())) {
+                if (date) {
                     results.push({
                         type: 'jsTimestamp',
                         date: date.toISOString(),
@@ -603,8 +675,8 @@ function extractJavaScriptTimestamps(html: string): Array<{
         const dataObjectPattern = /(?:article|page|post|document|content|data)(?:Data)?\s*[=:]\s*\{[\s\S]*?(?:updated|modified|published|date)(?:At|On|Date|Time)?\s*[=:]\s*["']?([^,"'\}\s]+)["']?/i;
         const dataObjectMatch = scriptContent.match(dataObjectPattern);
         if (dataObjectMatch && dataObjectMatch[1]) {
-            const date = new Date(dataObjectMatch[1]);
-            if (!isNaN(date.getTime())) {
+            const date = toPlausibleDate(dataObjectMatch[1]);
+            if (date) {
                 results.push({
                     type: 'jsDataObject',
                     date: date.toISOString(),
@@ -626,8 +698,8 @@ function extractJavaScriptTimestamps(html: string): Array<{
             const dateFields = ['dateModified', 'dateUpdated', 'datePublished', 'uploadDate'];
             for (const field of dateFields) {
                 if (jsonLd[field]) {
-                    const date = new Date(jsonLd[field]);
-                    if (!isNaN(date.getTime())) {
+                    const date = toPlausibleDate(jsonLd[field]);
+                    if (date) {
                         results.push({
                             type: 'jsonLd',
                             field: field,
@@ -675,13 +747,25 @@ async function extractFeedTimestamps(targetUrl: string): Promise<Array<{
             `${baseUrl}/sitemap.xml`
         ];
 
-        for (const feedUrl of feedUrls) {
-            try {
-                const response = await fetch(feedUrl);
-                if (!response.ok) continue;
+        // These were fetched one after another with no timeout, so a site that
+        // serves a slow 404 for /feed delayed the other six - up to 7 serial
+        // round-trips on every guess_datetime_url call. They are independent, so
+        // fan them out and bound each one. allSettled preserves feedUrls order,
+        // keeping the emitted results deterministic.
+        const fetched = await Promise.allSettled(
+            feedUrls.map(async (feedUrl) => {
+                const response = await fetch(feedUrl, {
+                    signal: AbortSignal.timeout(FEED_FETCH_TIMEOUT_MS),
+                });
+                if (!response.ok) return null;
+                return { feedUrl, text: await readCapped(response, MAX_FEED_BYTES) };
+            })
+        );
 
-                const text = await response.text();
-
+        for (const settled of fetched) {
+            if (settled.status !== 'fulfilled' || !settled.value) continue;
+            const { feedUrl, text } = settled.value;
+            {
                 // Check for RSS feed
                 if (text.includes('<rss') || text.includes('<rdf')) {
                     // Look for lastBuildDate in RSS
@@ -746,9 +830,6 @@ async function extractFeedTimestamps(targetUrl: string): Promise<Array<{
                         }
                     }
                 }
-            } catch (e) {
-                // Skip failed feed requests
-                continue;
             }
         }
     } catch (e) {
@@ -1081,8 +1162,8 @@ function determineBestUpdateTime(updateTimes: any) {
 
     // Use HTTP Last-Modified even if it matches server time, but with lower confidence
     if (updateTimes.lastModified) {
-        const lastModDate = new Date(updateTimes.lastModified);
-        if (!isNaN(lastModDate.getTime())) {
+        const lastModDate = toPlausibleDate(updateTimes.lastModified);
+        if (lastModDate) {
             // Check if Last-Modified differs significantly from server time
             if (updateTimes.date) {
                 const serverDate = new Date(updateTimes.date);
@@ -1141,13 +1222,15 @@ export async function guessDatetimeFromUrl(url: string): Promise<{
 }> {
     try {
         // Fetch the target webpage
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            signal: AbortSignal.timeout(PAGE_FETCH_TIMEOUT_MS),
+        });
 
         if (!response.ok) {
             throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
 
-        const text = await response.text();
+        const text = await readCapped(response, MAX_PAGE_BYTES);
 
         // Extract all possible time indicators
         const updateTimes = await extractAllTimeIndicators(response, text, url);

--- a/src/utils/image-downloader.ts
+++ b/src/utils/image-downloader.ts
@@ -16,10 +16,24 @@ interface ProcessedImageResult {
  * Automatically resizes to max 800px longest edge and converts to JPEG
  * Handles both single and batch downloads with timeout support
  */
+export interface ImageTransformOptions {
+    /** Max width in pixels (default 800) */
+    width?: number;
+    /**
+     * Max height in pixels (default 800), or `null` to constrain width only.
+     *
+     * `null` is what tall full-page screenshots need: `fit: 'scale-down'`
+     * preserves the aspect ratio, so an 800x800 box turns a 1280x20000 pageshot
+     * into a ~51px-wide sliver in which no text is legible.
+     */
+    height?: number | null;
+}
+
 export async function downloadImages(
     urls: string | string[],
     concurrencyLimit: number = 3,
-    timeoutMs: number = 15000
+    timeoutMs: number = 15000,
+    transform: ImageTransformOptions = {}
 ): Promise<ProcessedImageResult[]> {
     // Normalize input to always be an array
     const urlArray = Array.isArray(urls) ? urls : [urls];
@@ -28,89 +42,96 @@ export async function downloadImages(
         return [];
     }
 
-    const results: ProcessedImageResult[] = [];
-    const queue = [...urlArray];
+    const deadline = Date.now() + timeoutMs;
+    const maxHeight = transform.height === undefined ? 800 : transform.height;
 
-    // Create a timeout promise
-    const timeoutPromise = new Promise<ProcessedImageResult[]>((_, reject) => {
-        setTimeout(() => reject(new Error('Download timeout')), timeoutMs);
-    });
+    // Results are written by index, so the array always lines up with the input
+    // order and a partial run leaves no holes - callers index into it positionally.
+    const results: ProcessedImageResult[] = urlArray.map((url) => ({
+        url,
+        success: false,
+        mimeType: "image/jpeg",
+        error: "Download timed out",
+    }));
 
-    // Create the download promise
-    const downloadPromise = (async () => {
-        // Process images in batches
-        while (queue.length > 0) {
-            const batch = queue.splice(0, concurrencyLimit);
-            const batchPromises = batch.map(async (url) => {
-                try {
-                    // Skip SVG images as they can't be processed by Cloudflare image transformation
-                    if (url.toLowerCase().endsWith('.svg') || url.toLowerCase().includes('.svg?')) {
-                        return {
-                            url,
-                            success: false,
-                            mimeType: "image/jpeg",
-                            error: "SVG images are not supported for transformation"
-                        };
+    const downloadOne = async (url: string, remainingMs: number): Promise<ProcessedImageResult> => {
+        try {
+            // Skip SVG images as they can't be processed by Cloudflare image transformation
+            if (url.toLowerCase().endsWith('.svg') || url.toLowerCase().includes('.svg?')) {
+                return {
+                    url,
+                    success: false,
+                    mimeType: "image/jpeg",
+                    error: "SVG images are not supported for transformation"
+                };
+            }
+
+            // Use Cloudflare Workers image transformation
+            // This automatically handles resizing and format conversion
+            const response = await fetch(url, {
+                // Bound each request individually so one stalled host cannot burn
+                // the whole budget, and so the connection is actually released
+                signal: AbortSignal.timeout(remainingMs),
+                cf: {
+                    image: {
+                        fit: 'scale-down',              // Never enlarge, only shrink
+                        width: transform.width ?? 800,  // Max width
+                        ...(maxHeight === null ? {} : { height: maxHeight }),
+                        format: 'jpeg',    // Convert to JPEG
+                        quality: 85,       // Good quality with reasonable file size
+                        compression: 'fast' // Faster processing
                     }
-
-                    // Use Cloudflare Workers image transformation
-                    // This automatically handles resizing and format conversion
-                    const response = await fetch(url, {
-                        cf: {
-                            image: {
-                                fit: 'scale-down', // Never enlarge, only shrink
-                                width: 800,        // Max width
-                                height: 800,       // Max height
-                                format: 'jpeg',    // Convert to JPEG
-                                quality: 85,       // Good quality with reasonable file size
-                                compression: 'fast' // Faster processing
-                            }
-                        }
-                    } as any);
-
-                    if (!response.ok) {
-                        return {
-                            url,
-                            success: false,
-                            mimeType: "image/jpeg",
-                            error: `HTTP ${response.status}: ${response.statusText}`
-                        };
-                    }
-
-                    const arrayBuffer = await response.arrayBuffer();
-                    const base64Image = Buffer.from(arrayBuffer).toString('base64');
-
-                    return {
-                        url,
-                        success: true,
-                        data: base64Image,
-                        mimeType: "image/jpeg"
-                    };
-                } catch (error) {
-                    return {
-                        url,
-                        success: false,
-                        mimeType: "image/jpeg",
-                        error: error instanceof Error ? error.message : String(error)
-                    };
                 }
-            });
+            } as any);
 
-            const batchResults = await Promise.all(batchPromises);
-            results.push(...batchResults);
+            if (!response.ok) {
+                return {
+                    url,
+                    success: false,
+                    mimeType: "image/jpeg",
+                    error: `HTTP ${response.status}: ${response.statusText}`
+                };
+            }
+
+            const arrayBuffer = await response.arrayBuffer();
+            const base64Image = Buffer.from(arrayBuffer).toString('base64');
+
+            return {
+                url,
+                success: true,
+                data: base64Image,
+                mimeType: "image/jpeg"
+            };
+        } catch (error) {
+            return {
+                url,
+                success: false,
+                mimeType: "image/jpeg",
+                error: error instanceof Error ? error.message : String(error)
+            };
         }
+    };
 
-        return results;
-    })();
+    // A rolling pool rather than fixed batches: `queue.splice(0, limit)` +
+    // Promise.all meant every batch ran at the speed of its slowest image, and a
+    // timeout mid-batch discarded that batch's completed downloads entirely.
+    // Here each worker takes the next index as soon as it frees up, and every
+    // finished download is committed immediately.
+    let next = 0;
+    const worker = async () => {
+        for (;;) {
+            const index = next++;
+            if (index >= urlArray.length) return;
 
-    // Race between download completion and timeout
-    try {
-        return await Promise.race([downloadPromise, timeoutPromise]);
-    } catch (error) {
-        if (error instanceof Error && error.message === 'Download timeout') {
-            // Return what we have so far
-            return results;
+            const remainingMs = deadline - Date.now();
+            if (remainingMs <= 0) return; // leave the pre-filled timeout entry in place
+
+            results[index] = await downloadOne(urlArray[index], remainingMs);
         }
-        throw error;
-    }
+    };
+
+    const poolSize = Math.max(1, Math.min(concurrencyLimit, urlArray.length));
+    await Promise.all(Array.from({ length: poolSize }, worker));
+
+    return results;
 }

--- a/src/utils/read.ts
+++ b/src/utils/read.ts
@@ -1,4 +1,9 @@
 import { normalizeUrl } from "./url-normalizer.js";
+import { withDeadline } from "./timeout.js";
+
+// r.jina.ai had no client-side deadline: a hung read held the Worker invocation
+// open until the platform killed it, taking the sibling reads down with it.
+const READ_REQUEST_TIMEOUT_MS = 30000;
 
 // ============================================================================
 // TYPES AND INTERFACES
@@ -66,6 +71,7 @@ export async function readUrlFromConfig(
 
         const response = await fetch('https://r.jina.ai/', {
             method: 'POST',
+            signal: AbortSignal.timeout(READ_REQUEST_TIMEOUT_MS),
             headers,
             body: JSON.stringify({ url: normalizedUrl }),
         });
@@ -121,14 +127,16 @@ export async function executeParallelUrlReads(
     bearerToken?: string,
     timeout: number = 30000
 ): Promise<ReadUrlResponse[]> {
-    const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('Parallel URL read timeout')), timeout)
+    // Per-URL deadline. The whole batch used to be raced against one rejecting
+    // timeout, so one slow page threw away every read that had already
+    // succeeded and the caller got a single generic error instead.
+    return Promise.all(
+        urlConfigs.map((urlConfig) =>
+            withDeadline<ReadUrlResponse>(
+                () => readUrlFromConfig(urlConfig, bearerToken),
+                timeout,
+                () => ({ error: `Read timed out after ${timeout}ms`, url: urlConfig.url })
+            )
+        )
     );
-
-    const readPromises = urlConfigs.map(urlConfig => readUrlFromConfig(urlConfig, bearerToken));
-
-    return Promise.race([
-        Promise.all(readPromises),
-        timeoutPromise
-    ]);
 }

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,4 +1,10 @@
 import { stringify as yamlStringify } from "yaml";
+import { withDeadline } from "./timeout.js";
+
+// A single search/read had no client-side deadline at all: a hung upstream held
+// the Worker invocation open until the platform killed it. Every outbound call
+// now carries an AbortSignal so the request is actually cancelled, not abandoned.
+const SEARCH_REQUEST_TIMEOUT_MS = 30000;
 
 // ============================================================================
 // TYPES AND INTERFACES
@@ -71,6 +77,7 @@ export async function executeWebSearch(
     try {
         const response = await fetch('https://svip.jina.ai/', {
             method: 'POST',
+            signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
@@ -107,6 +114,7 @@ export async function executeArxivSearch(
     try {
         const response = await fetch('https://svip.jina.ai/', {
             method: 'POST',
+            signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
@@ -141,6 +149,7 @@ export async function executeSsrnSearch(
     try {
         const response = await fetch('https://svip.jina.ai/', {
             method: 'POST',
+            signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
@@ -200,6 +209,9 @@ export interface JinaBlogRerankConfig {
 }
 
 let blogPostCache: { fetchedAt: number; posts: IndexedBlogPost[] } | null = null;
+// Concurrent cold requests used to each pull the whole catalog; they now share
+// one in-flight fetch.
+let blogPostCacheInFlight: Promise<IndexedBlogPost[]> | null = null;
 
 const BLOG_STOPWORDS = new Set([
     'a', 'about', 'an', 'and', 'are', 'as', 'at', 'be', 'by', 'can', 'do', 'does',
@@ -244,6 +256,21 @@ async function fetchIndexedBlogPosts(ghostApiKey: string): Promise<IndexedBlogPo
         return blogPostCache.posts;
     }
 
+    // Single-flight: a burst of requests arriving on a cold isolate (or a
+    // parallel_search over N queries, which calls this N times at once) would
+    // otherwise each download the entire post catalog.
+    if (blogPostCacheInFlight) {
+        return blogPostCacheInFlight;
+    }
+
+    blogPostCacheInFlight = fetchAndIndexBlogPosts(ghostApiKey).finally(() => {
+        blogPostCacheInFlight = null;
+    });
+
+    return blogPostCacheInFlight;
+}
+
+async function fetchAndIndexBlogPosts(ghostApiKey: string): Promise<IndexedBlogPost[]> {
     const params = new URLSearchParams({
         key: ghostApiKey,
         limit: 'all',
@@ -253,6 +280,7 @@ async function fetchIndexedBlogPosts(ghostApiKey: string): Promise<IndexedBlogPo
 
     const response = await fetch(`${GHOST_POSTS_ENDPOINT}?${params.toString()}`, {
         method: 'GET',
+        signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
         headers: { 'Accept': 'application/json' },
     });
 
@@ -344,6 +372,7 @@ async function rerankBlogPosts(
     try {
         const response = await fetch(`${config.apiBaseUrl || 'https://api.jina.ai'}/v1/rerank`, {
             method: 'POST',
+            signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
@@ -418,6 +447,7 @@ export async function executeImageSearch(
     try {
         const response = await fetch('https://svip.jina.ai/', {
             method: 'POST',
+            signal: AbortSignal.timeout(SEARCH_REQUEST_TIMEOUT_MS),
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
@@ -458,24 +488,25 @@ export async function executeParallelSearches<T>(
 ): Promise<ParallelSearchResult[]> {
     const { timeout = 30000 } = options;
 
-    // Execute all searches in parallel
-    const searchPromises = searches.map(async (searchArgs) => {
-        try {
-            return await searchFunction(searchArgs);
-        } catch (error) {
-            return { error: `Search failed: ${error instanceof Error ? error.message : String(error)}` } as SearchError;
-        }
-    });
-
-    // Race all searches against timeout
-    const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Parallel search timed out after ${timeout}ms`)), timeout)
+    // Each search gets its own deadline. Previously the whole batch was raced
+    // against one rejecting timeout, so a single slow query discarded every
+    // search that had already come back - the caller saw one generic timeout
+    // error instead of the results it had actually paid for.
+    return Promise.all(
+        searches.map((searchArgs) =>
+            withDeadline<SearchResultOrError>(
+                async () => {
+                    try {
+                        return await searchFunction(searchArgs);
+                    } catch (error) {
+                        return { error: `Search failed: ${error instanceof Error ? error.message : String(error)}` } as SearchError;
+                    }
+                },
+                timeout,
+                () => ({ error: `Search timed out after ${timeout}ms` })
+            )
+        )
     );
-
-    return Promise.race([
-        Promise.all(searchPromises),
-        timeoutPromise
-    ]);
 }
 
 // ============================================================================

--- a/src/utils/submodular-optimization.ts
+++ b/src/utils/submodular-optimization.ts
@@ -17,6 +17,63 @@ export function cosineSimilarity(a: number[], b: number[]): number {
     return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
 }
 
+/**
+ * Pairwise cosine similarity matrix, clamped to non-negative so the
+ * facility-location objective stays monotone submodular.
+ *
+ * Building this used to call cosineSimilarity() for all n^2 ordered pairs, which
+ * re-derived both vector norms on every call - 3 passes over d floats per pair,
+ * and every pair computed twice. Here the norms are computed once (O(n*d)) and
+ * only the upper triangle is evaluated, so the dominant term drops from
+ * 3*n^2*d to n^2*d/2. Results are bit-identical to the previous implementation.
+ *
+ * Returned as a flat Float64Array (n*n) to avoid n separate JS arrays.
+ */
+function buildSimilarityMatrix(embeddings: number[][]): Float64Array {
+    const n = embeddings.length;
+
+    // sumSquares[i] and norms[i] are derived once per vector instead of once per pair
+    const sumSquares = new Float64Array(n);
+    const norms = new Float64Array(n);
+    for (let i = 0; i < n; i++) {
+        const v = embeddings[i];
+        let total = 0;
+        for (let t = 0; t < v.length; t++) total += v[t] * v[t];
+        sumSquares[i] = total;
+        norms[i] = Math.sqrt(total);
+    }
+
+    const matrix = new Float64Array(n * n);
+    for (let i = 0; i < n; i++) {
+        const vi = embeddings[i];
+        const normI = norms[i];
+
+        // Same expression cosineSimilarity(v, v) evaluates to, kept verbatim rather
+        // than shortcut to 1: sqrt(x)*sqrt(x) is not exactly x in IEEE-754, and the
+        // selection order depends on those last bits when gains tie.
+        const self = sumSquares[i] === 0 ? 0 : sumSquares[i] / (normI * normI);
+        matrix[i * n + i] = self > 0 ? self : 0;
+
+        for (let j = i + 1; j < n; j++) {
+            const vj = embeddings[j];
+            let sim = 0;
+            // cosineSimilarity() returns 0 for mismatched lengths or a zero vector
+            if (vi.length === vj.length && sumSquares[i] !== 0 && sumSquares[j] !== 0) {
+                let dot = 0;
+                for (let t = 0; t < vi.length; t++) dot += vi[t] * vj[t];
+                sim = dot / (normI * norms[j]);
+            }
+            // Clamp to non-negative to ensure monotone submodularity of the
+            // facility-location objective (NaN falls through to 0, as before)
+            const clamped = sim > 0 ? sim : 0;
+            matrix[i * n + j] = clamped;
+            matrix[j * n + i] = clamped;
+        }
+    }
+
+    return matrix;
+}
+
 export function computeMarginalGainDiversity(
     newIdx: number,
     currentCoverage: number[],
@@ -32,59 +89,120 @@ export function computeMarginalGainDiversity(
     return marginalGain;
 }
 
+/** Marginal gain of adding `idx` to the selected set, over the flat matrix */
+function marginalGain(
+    matrix: Float64Array,
+    n: number,
+    idx: number,
+    coverage: Float64Array
+): number {
+    let gain = 0;
+    const offset = idx * n;
+    for (let i = 0; i < n; i++) {
+        const sim = matrix[offset + i];
+        if (sim > coverage[i]) gain += sim - coverage[i];
+    }
+    return gain;
+}
+
+/** [gain, lastUpdatedIteration, index, insertionSeq] */
+type HeapEntry = [number, number, number, number];
+
+/**
+ * Max-heap over marginal gains for the lazy-greedy loop.
+ *
+ * The previous implementation used a plain array as the queue: `shift()` is O(n)
+ * and it re-ran a full `sort()` after *every* stale-gain re-insertion, so each
+ * re-evaluation cost O(n log n) on top of the O(n) gain computation.
+ *
+ * Ties are broken by ascending insertion sequence, which is exactly what the old
+ * stable `sort()` did (re-inserted entries were appended, so they sorted after
+ * equal-gain entries already in the queue). Selections are therefore unchanged.
+ */
+class GainHeap {
+    private items: HeapEntry[] = [];
+    private seq = 0;
+
+    get size(): number {
+        return this.items.length;
+    }
+
+    private static higher(a: HeapEntry, b: HeapEntry): boolean {
+        return a[0] !== b[0] ? a[0] > b[0] : a[3] < b[3];
+    }
+
+    push(gain: number, lastUpdated: number, index: number): void {
+        const items = this.items;
+        items.push([gain, lastUpdated, index, this.seq++]);
+        let i = items.length - 1;
+        while (i > 0) {
+            const parent = (i - 1) >> 1;
+            if (!GainHeap.higher(items[i], items[parent])) break;
+            [items[parent], items[i]] = [items[i], items[parent]];
+            i = parent;
+        }
+    }
+
+    pop(): HeapEntry | undefined {
+        const items = this.items;
+        if (items.length === 0) return undefined;
+        const top = items[0];
+        const last = items.pop() as HeapEntry;
+        if (items.length > 0) {
+            items[0] = last;
+            let i = 0;
+            for (;;) {
+                const left = 2 * i + 1;
+                const right = left + 1;
+                let best = i;
+                if (left < items.length && GainHeap.higher(items[left], items[best])) best = left;
+                if (right < items.length && GainHeap.higher(items[right], items[best])) best = right;
+                if (best === i) break;
+                [items[best], items[i]] = [items[i], items[best]];
+                i = best;
+            }
+        }
+        return top;
+    }
+}
+
 export function lazyGreedySelection(embeddings: number[][], k: number): number[] {
     const n = embeddings.length;
     if (k >= n) return Array.from({ length: n }, (_, i) => i);
 
-    const selected: number[] = [];
-    const remaining = new Set(Array.from({ length: n }, (_, i) => i));
-
-    // Pre-compute similarity matrix
-    const similarityMatrix: number[][] = [];
-    for (let i = 0; i < n; i++) {
-        similarityMatrix[i] = [];
-        for (let j = 0; j < n; j++) {
-            // Clamp to non-negative to ensure monotone submodularity of facility-location objective
-            const sim = cosineSimilarity(embeddings[i], embeddings[j]);
-            similarityMatrix[i][j] = sim > 0 ? sim : 0;
-        }
-    }
+    const matrix = buildSimilarityMatrix(embeddings);
 
     // Maintain current coverage vector (max similarity to selected set for each element)
-    const currentCoverage = new Array(n).fill(0);
+    const coverage = new Float64Array(n);
+    const selected: number[] = [];
+    const picked = new Uint8Array(n);
 
-    // Priority queue implementation using array (simplified)
-    const pq: Array<[number, number, number]> = [];
-
-    // Initialize priority queue
+    const heap = new GainHeap();
     for (let i = 0; i < n; i++) {
-        const gain = computeMarginalGainDiversity(i, currentCoverage, similarityMatrix);
-        pq.push([-gain, 0, i]);
+        heap.push(marginalGain(matrix, n, i, coverage), 0, i);
     }
 
-    // Sort by gain (descending)
-    pq.sort((a, b) => a[0] - b[0]);
+    for (let iteration = 0; iteration < k && heap.size > 0; iteration++) {
+        for (;;) {
+            const top = heap.pop();
+            if (!top) break;
+            const [, lastUpdated, bestIdx] = top;
 
-    for (let iteration = 0; iteration < k; iteration++) {
-        while (pq.length > 0) {
-            const [negGain, lastUpdated, bestIdx] = pq.shift()!;
-
-            if (!remaining.has(bestIdx)) continue;
+            if (picked[bestIdx]) continue;
 
             if (lastUpdated === iteration) {
+                picked[bestIdx] = 1;
                 selected.push(bestIdx);
-                remaining.delete(bestIdx);
                 // Update coverage in O(n)
-                const row = similarityMatrix[bestIdx];
+                const offset = bestIdx * n;
                 for (let i = 0; i < n; i++) {
-                    if (row[i] > currentCoverage[i]) currentCoverage[i] = row[i];
+                    if (matrix[offset + i] > coverage[i]) coverage[i] = matrix[offset + i];
                 }
                 break;
             }
 
-            const currentGain = computeMarginalGainDiversity(bestIdx, currentCoverage, similarityMatrix);
-            pq.push([-currentGain, iteration, bestIdx]);
-            pq.sort((a, b) => a[0] - b[0]);
+            // Stale gain: re-evaluate and re-insert (the "lazy" part of lazy greedy)
+            heap.push(marginalGain(matrix, n, bestIdx, coverage), iteration, bestIdx);
         }
     }
 
@@ -97,67 +215,54 @@ export function lazyGreedySelectionWithSaturation(
 ): { selected: number[], optimalK: number, values: number[] } {
     const n = embeddings.length;
 
+    const matrix = buildSimilarityMatrix(embeddings);
+
+    const coverage = new Float64Array(n);
     const selected: number[] = [];
-    const remaining = new Set(Array.from({ length: n }, (_, i) => i));
+    const picked = new Uint8Array(n);
     const values: number[] = [];
 
-    // Pre-compute similarity matrix
-    const similarityMatrix: number[][] = [];
+    const heap = new GainHeap();
     for (let i = 0; i < n; i++) {
-        similarityMatrix[i] = [];
-        for (let j = 0; j < n; j++) {
-            const sim = cosineSimilarity(embeddings[i], embeddings[j]);
-            similarityMatrix[i][j] = sim > 0 ? sim : 0;
-        }
+        heap.push(marginalGain(matrix, n, i, coverage), 0, i);
     }
-
-    const currentCoverage = new Array(n).fill(0);
-
-    // Priority queue implementation using array (simplified)
-    const pq: Array<[number, number, number]> = [];
-
-    // Initialize priority queue
-    for (let i = 0; i < n; i++) {
-        const gain = computeMarginalGainDiversity(i, currentCoverage, similarityMatrix);
-        pq.push([-gain, 0, i]);
-    }
-
-    // Sort by gain (descending)
-    pq.sort((a, b) => a[0] - b[0]);
 
     let earlyStopK: number | null = null;
-    for (let iteration = 0; iteration < n; iteration++) {
-        while (pq.length > 0) {
-            const [negGain, lastUpdated, bestIdx] = pq.shift()!;
+    for (let iteration = 0; iteration < n && heap.size > 0; iteration++) {
+        for (;;) {
+            const top = heap.pop();
+            if (!top) break;
+            const [, lastUpdated, bestIdx] = top;
 
-            if (!remaining.has(bestIdx)) continue;
+            if (picked[bestIdx]) continue;
 
             if (lastUpdated === iteration) {
+                picked[bestIdx] = 1;
                 selected.push(bestIdx);
-                remaining.delete(bestIdx);
 
                 // Compute current function value (coverage)
-                const row = similarityMatrix[bestIdx];
+                const offset = bestIdx * n;
+                let total = 0;
                 for (let i = 0; i < n; i++) {
-                    if (row[i] > currentCoverage[i]) currentCoverage[i] = row[i];
+                    if (matrix[offset + i] > coverage[i]) coverage[i] = matrix[offset + i];
+                    total += coverage[i];
                 }
-                const functionValue = currentCoverage.reduce((sum, val) => sum + val, 0) / n;
-                values.push(functionValue);
+                values.push(total / n);
 
-                // Early stop when the marginal gain (delta of normalized objective) falls below threshold
+                // Early stop once the marginal gain (delta of the normalized objective)
+                // falls below the threshold. The element that produced that sub-threshold
+                // delta is itself redundant, so k is the count *before* it was added.
                 if (values.length >= 2) {
                     const delta = values[values.length - 1] - values[values.length - 2];
                     if (delta < threshold) {
-                        earlyStopK = values.length; // k is count of selected items
+                        earlyStopK = values.length - 1;
                     }
                 }
 
                 break;
             }
 
-            const currentGain = computeMarginalGainDiversity(bestIdx, currentCoverage, similarityMatrix);
-            pq.push([-currentGain, iteration, bestIdx]);
-            pq.sort((a, b) => a[0] - b[0]);
+            heap.push(marginalGain(matrix, n, bestIdx, coverage), iteration, bestIdx);
         }
         if (earlyStopK !== null) break;
     }

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,29 @@
+/**
+ * Run `task` with a deadline, resolving to `onTimeout()` instead of rejecting.
+ *
+ * The parallel tools used to race `Promise.all([...])` against a single rejecting
+ * timeout promise. When that timeout won, the whole batch rejected and the tool's
+ * catch block turned every already-completed search/read into one generic error
+ * string - work that had finished successfully was thrown away.
+ *
+ * Giving each task its own deadline keeps the slow one isolated: it degrades to
+ * an error entry while its siblings return their real results. The timer is
+ * always cleared, so a fast batch leaves no pending timers behind.
+ */
+export async function withDeadline<T>(
+    task: () => Promise<T>,
+    timeoutMs: number,
+    onTimeout: () => T
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const deadline = new Promise<T>((resolve) => {
+        timer = setTimeout(() => resolve(onTimeout()), timeoutMs);
+    });
+
+    try {
+        return await Promise.race([task(), deadline]);
+    } finally {
+        if (timer !== undefined) clearTimeout(timer);
+    }
+}

--- a/src/utils/token-guardrail.ts
+++ b/src/utils/token-guardrail.ts
@@ -20,37 +20,79 @@ interface TokenCountResult {
     tokenizer: string;
 }
 
+// /v1/segment rejects content of 64k characters or more ("Content length must be
+// greater than 0 and less than 64k"), which is *exactly* the size range the
+// guardrail cares about: 25k tokens of English prose is ~100k characters. Every
+// oversized document therefore used to 400 - after uploading the whole body -
+// and silently fall back to a flat chars/4 guess. Count in chunks instead.
+const SEGMENT_MAX_CHARS = 60000;
+const SEGMENT_TIMEOUT_MS = 15000;
+
+/** Rough local estimate, used only when the API is unavailable */
+function estimateTokens(content: string): number {
+    // ~4 chars/token holds for Latin script but overshoots badly for CJK, where a
+    // character is closer to one token. Split the difference by script mix rather
+    // than assuming English.
+    const cjkCount = (content.match(/[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]/g) || []).length;
+    const rest = content.length - cjkCount;
+    return Math.ceil(cjkCount + rest / 4);
+}
+
+async function countSegmentChunk(chunk: string, bearerToken: string, apiBaseUrl: string): Promise<number> {
+    const response = await fetch(`${apiBaseUrl}/v1/segment`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(SEGMENT_TIMEOUT_MS),
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${bearerToken}`,
+        },
+        body: JSON.stringify({ content: chunk }),
+    });
+
+    if (!response.ok) {
+        throw new Error(`segment failed: ${response.status}`);
+    }
+
+    const data = await response.json() as TokenCountResult;
+    return data.num_tokens;
+}
+
 /**
  * Count tokens using Jina Segment API
  */
 async function countTokens(content: string, bearerToken: string, apiBaseUrl: string = 'https://api.jina.ai'): Promise<number> {
+    const chunks: string[] = [];
+    for (let i = 0; i < content.length; i += SEGMENT_MAX_CHARS) {
+        chunks.push(content.slice(i, i + SEGMENT_MAX_CHARS));
+    }
+
     try {
-        const response = await fetch(`${apiBaseUrl}/v1/segment`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${bearerToken}`,
-            },
-            body: JSON.stringify({ content }),
-        });
-
-        if (!response.ok) {
-            // Fallback: rough estimate (1 token ≈ 4 chars for English)
-            return Math.ceil(content.length / 4);
-        }
-
-        const data = await response.json() as TokenCountResult;
-        return data.num_tokens;
+        const counts = await Promise.all(
+            chunks.map((chunk) => countSegmentChunk(chunk, bearerToken, apiBaseUrl))
+        );
+        // Summing per-chunk counts can differ from a single-pass count by at most
+        // one token per boundary, which is immaterial against a 25k budget.
+        return counts.reduce((sum, n) => sum + n, 0);
     } catch {
-        // Fallback: rough estimate
-        return Math.ceil(content.length / 4);
+        return estimateTokens(content);
     }
 }
 
+/** Reserve a little budget for the "content was truncated" notice */
+const TRUNCATION_NOTICE_TOKENS = 64;
+
 /**
- * Truncate text content items in a structure-safe way
- * - For single large item: truncate the text content
- * - For multiple items: keep items until adding next would exceed limit
+ * Truncate text content items so the response fits the client's budget.
+ *
+ * - Token counts for every item are resolved concurrently. They used to be
+ *   awaited one at a time, so a 5-URL parallel_read_url paid five *sequential*
+ *   /v1/segment round-trips after the reads had already finished.
+ * - Original item order is preserved (images used to be hoisted ahead of text).
+ * - At least one text item always survives: previously, if the very first item
+ *   was on its own over budget the loop broke immediately and the caller got a
+ *   response with no text content at all, silently.
+ * - Dropped/truncated content is reported instead of vanishing, so the model
+ *   knows it is looking at a partial document.
  */
 async function truncateContentItems(
     contentItems: ContentItem[],
@@ -59,55 +101,93 @@ async function truncateContentItems(
     apiBaseUrl: string = 'https://api.jina.ai'
 ): Promise<ContentItem[]> {
     const textItems = contentItems.filter((item): item is TextContentItem => item.type === 'text');
-    const nonTextItems = contentItems.filter((item): item is ImageContentItem => item.type !== 'text');
-
     if (textItems.length === 0) {
         return contentItems;
     }
 
-    // Single item case: truncate the text if too large
-    if (textItems.length === 1) {
-        const item = textItems[0];
-        const tokens = await countTokens(item.text, bearerToken, apiBaseUrl);
+    // A token never spans fewer than one UTF-8 byte, so a response whose total
+    // byte length is already within budget cannot exceed it in tokens. Checking
+    // that first skips the /v1/segment round-trips entirely for ordinary pages,
+    // instead of uploading every document just to be told it fits.
+    const totalBytes = textItems.reduce((sum, item) => sum + Buffer.byteLength(item.text, 'utf8'), 0);
+    if (totalBytes <= maxTokens) {
+        return contentItems;
+    }
 
-        if (tokens <= maxTokens) {
-            return contentItems;
+    const tokenCounts = new Map<TextContentItem, number>();
+    await Promise.all(
+        textItems.map(async (item) => {
+            tokenCounts.set(item, await countTokens(item.text, bearerToken, apiBaseUrl));
+        })
+    );
+
+    const totalTokens = [...tokenCounts.values()].reduce((sum, n) => sum + n, 0);
+    if (totalTokens <= maxTokens) {
+        return contentItems;
+    }
+
+    const budget = maxTokens - TRUNCATION_NOTICE_TOKENS;
+    const kept: ContentItem[] = [];
+    let used = 0;
+    let droppedItems = 0;
+    let truncated = false;
+
+    for (const item of contentItems) {
+        if (item.type !== 'text') {
+            kept.push(item);
+            continue;
         }
 
-        // Truncate text proportionally (use full ratio since no notice appended)
-        const keepRatio = maxTokens / tokens;
-        const truncatedLength = Math.floor(item.text.length * keepRatio);
+        const itemTokens = tokenCounts.get(item) ?? 0;
 
-        return [
-            ...nonTextItems,
-            {
-                type: 'text',
-                text: item.text.substring(0, truncatedLength)
+        if (used + itemTokens <= budget) {
+            kept.push(item);
+            used += itemTokens;
+            continue;
+        }
+
+        // First item that does not fit: spend whatever budget is left on a prefix
+        // of it, then drop the rest. This is what guarantees the caller always
+        // gets *some* content back, even when item one alone blows the budget.
+        const remaining = budget - used;
+        if (!truncated && remaining > 0 && itemTokens > 0) {
+            // Proportional character cut - approximate, but token density is
+            // roughly uniform within a single document
+            const keepChars = Math.floor(item.text.length * (remaining / itemTokens));
+            if (keepChars > 0) {
+                kept.push({ type: 'text', text: item.text.slice(0, keepChars) });
+                used = budget;
+                truncated = true;
+                continue;
             }
-        ];
-    }
-
-    // Multiple items case: keep adding until would exceed limit
-    const keptItems: TextContentItem[] = [];
-    let totalTokens = 0;
-
-    for (const item of textItems) {
-        const itemTokens = await countTokens(item.text, bearerToken, apiBaseUrl);
-
-        if (totalTokens + itemTokens > maxTokens) {
-            // Adding this item would exceed limit, stop here
-            break;
         }
 
-        keptItems.push(item);
-        totalTokens += itemTokens;
+        droppedItems++;
     }
 
-    return [...nonTextItems, ...keptItems];
+    const notes: string[] = [];
+    if (truncated) notes.push('content was truncated to fit the client token limit');
+    if (droppedItems > 0) notes.push(`${droppedItems} further result(s) omitted`);
+    if (notes.length > 0) {
+        kept.push({
+            type: 'text',
+            text: `[jina-mcp] Response exceeded the ${maxTokens}-token client limit: ${notes.join('; ')}. Re-run with fewer URLs, or read the omitted URLs individually, to see the rest.`,
+        });
+    }
+
+    return kept;
 }
 
 /**
  * Check if client needs token guardrail
+ *
+ * `clientName` can no longer come only from server.getClientVersion(): the MCP
+ * `initialize` request that carries clientInfo is handled in a *different* Worker
+ * invocation than the `tools/call` that needs it, and this deployment is stateless
+ * (createMcpHandler gets no `storage`, so WorkerTransport never replays
+ * initializeParams). getClientVersion() is therefore undefined at tool-call time
+ * and this predicate always returned false - the whole truncation path was dead.
+ * index.ts now also passes the transport User-Agent as a fallback hint.
  */
 export function shouldApplyGuardrail(clientName: string | undefined): boolean {
     if (!clientName) return false;
@@ -116,16 +196,22 @@ export function shouldApplyGuardrail(clientName: string | undefined): boolean {
 
 /**
  * Apply token guardrail to MCP tool response
- * Only applies to known clients with token limits (Claude Code, Claude Desktop, Cursor)
+ *
+ * Applies to known limited clients (Claude Code, Claude Desktop, Cursor), or to
+ * any client that states its own budget with `?max_tokens=` on the endpoint URL.
+ * `?max_tokens=0` opts out entirely.
  */
 export async function applyTokenGuardrail(
     response: { content: ContentItem[]; isError?: boolean },
     bearerToken: string,
     clientName?: string,
-    apiBaseUrl: string = 'https://api.jina.ai'
+    apiBaseUrl: string = 'https://api.jina.ai',
+    explicitMaxTokens?: number
 ): Promise<{ content: ContentItem[]; isError?: boolean }> {
-    // Skip guardrail if not a known limited client
-    if (!shouldApplyGuardrail(clientName)) {
+    const maxTokens = explicitMaxTokens ?? (shouldApplyGuardrail(clientName) ? MAX_TOKENS : undefined);
+
+    // Not a known limited client and no declared budget
+    if (maxTokens === undefined || maxTokens <= 0) {
         return response;
     }
 
@@ -136,7 +222,7 @@ export async function applyTokenGuardrail(
     const truncatedContent = await truncateContentItems(
         response.content,
         bearerToken,
-        MAX_TOKENS,
+        maxTokens,
         apiBaseUrl
     );
 
@@ -145,12 +231,3 @@ export async function applyTokenGuardrail(
         content: truncatedContent
     };
 }
-
-/**
- * List of tool names that should have token guardrail applied
- * Focus on tools that return full content (not just snippets/metadata)
- */
-export const GUARDRAIL_TOOLS = [
-    'read_url',
-    'parallel_read_url',
-];

--- a/src/utils/url-normalizer.ts
+++ b/src/utils/url-normalizer.ts
@@ -7,9 +7,16 @@ export function normalizeUrl(urlString: string, options = {
 	removeXAnalytics: true
 }) {
 	try {
-		urlString = urlString.replace(/\s+/g, '').trim();
+		// Only strip leading/trailing whitespace and the C0 control characters the
+		// WHATWG URL parser ignores. Collapsing *all* whitespace deleted spaces
+		// inside the path and query too, so
+		// "https://en.wikipedia.org/wiki/New York City" was fetched as
+		// ".../NewYorkCity" and the caller was told the original URL had 404'd.
+		// new URL() percent-encodes interior spaces correctly on its own.
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: C0 controls are exactly what must be removed
+		urlString = urlString.trim().replace(/[\u0000-\u001F\u007F]/g, '');
 
-		if (!urlString?.trim()) {
+		if (!urlString) {
 			throw new Error('Empty URL');
 		}
 


### PR DESCRIPTION
Review pass over the whole worker for correctness and performance. Every item below was confirmed by reading the code and, where the failure is reproducible, by running the old and new implementations side by side. Nothing here is speculative — findings I could not substantiate were dropped.

`tsc --noEmit` and `wrangler deploy --dry-run` both pass.

## Highest-impact findings

**The token guardrail has never run in production.** `getClientName()` reads `server.server.getClientVersion()`, but the SDK only sets `_clientVersion` inside `_oninitialize`, on the server instance that handled `initialize`. `index.ts` builds a fresh `McpServer` per `fetch`, and `createMcpHandler` is called without `storage`, so `WorkerTransport.restoreState()` returns immediately and `initializeParams` are never replayed. A `tools/call` is a separate invocation from `initialize`, so the client name is always `undefined`, `shouldApplyGuardrail(undefined)` is always `false`, and the entire truncation path in `token-guardrail.ts` is dead. Claude Code/Desktop/Cursor have been getting untruncated `read_url` responses this whole time.

**`/v1/segment` can't count the documents the guardrail cares about.** The endpoint rejects content of 64k characters or more, and 25k tokens of English prose is ~100k characters — so every oversized document 400'd *after* uploading its full body, and counting silently fell back to a flat `chars/4`. That under-counts CJK by roughly 4.7x. Now chunked, with a script-aware fallback and a byte-length short-circuit that skips the network call entirely when the response is already under budget.

**A parallel timeout threw away every result that had already succeeded.** `executeParallelSearches` / `executeParallelUrlReads` raced `Promise.all` against a single rejecting timeout; when it won, the tool's `catch` collapsed the whole batch into one generic error string, discarding completed reads and the credits spent on them. Deadlines are now per item, so a slow URL degrades to one error entry among real results.

**`search_bibtex` had two crashes reachable from ordinary queries.** Both reproduced against the current code and fixed:

| input | before | after |
|---|---|---|
| DBLP record with array-valued `venue` (13 of 100 hits on "information retrieval evaluation") | `TypeError: str.replace is not a function` — discards *all* DBLP results | parses |
| 3 distinct 2023 papers titled "A Survey of…", "A Comprehensive Study of…", "A Review of…" | 1 of 3 returned | 3 of 3 |
| record chain where a DOI is registered for an entry later merged away | `TypeError: Cannot read properties of undefined (reading 'doi')` | parses |

The dedup map was keyed by citation key, so any two papers sharing a first title word and year silently overwrote each other.

## Performance

`submodular-optimization.ts` builds an n×n cosine matrix for `deduplicate_strings` / `deduplicate_images`. It called `cosineSimilarity()` for all n² *ordered* pairs, re-deriving both vector norms every time — three passes over d floats per pair, every pair computed twice. The priority queue was an array using `shift()` (O(n)) plus a full `sort()` after every stale-gain re-insertion.

Norms are now computed once, only the upper triangle is evaluated, and the queue is a binary heap. Measured on `jina-embeddings-v5-text-small` shapes (d=1024, L2-normalized, 12 clusters):

```
    n |    k | before(ms) | after(ms) | speedup
  ----+------+------------+-----------+--------
   50 |   10 |        1.9 |       1.0 |   1.90x
  100 |   20 |        7.7 |       3.6 |   2.12x
  200 |   40 |       30.1 |      14.5 |   2.08x
  400 |   80 |      122.2 |      55.6 |   2.20x
  800 |  100 |      485.9 |     217.1 |   2.24x
 1500 |  100 |     1734.8 |     773.3 |   2.24x
```

**Selections are bit-identical.** Reproducing the old behaviour exactly took two details worth flagging to a reviewer: the diagonal is `sumSquares/(norm*norm)`, not `1`, because `sqrt(x)*sqrt(x) !== x` in IEEE-754 and the last bits decide ties; and heap ties break by insertion sequence, which is what the old stable `sort()` did. A differential harness over 1008 cases (d ∈ {4,32,256,1024}, n ∈ {1..150}, normalized and not, with duplicate and zero vectors, k ∈ {1,2,n/2,n,n+3}) reports 0 mismatches.

Also: guardrail token counts now resolve concurrently instead of one round-trip at a time; `guess_datetime_url` fetches its 7 candidate feed URLs concurrently instead of serially (it was up to 7 sequential round-trips, none with a timeout); `downloadImages` uses a rolling pool instead of fixed batches, which were running at the speed of the slowest image and dropping the whole in-flight batch on timeout; and the blog post catalog is single-flighted so concurrent cold requests don't each download it.

## Other correctness fixes

- **`guess-datetime.ts`** — `[\\s\\S]` written inside a regex *literal* is the three-character class `{\, s, S}`, not "any character", so the deploy-comment pattern only matched if nothing but backslashes and s/S sat between the date and `-->`.
- **`guess-datetime.ts`** — dates are now range-checked. The "most recent date found in page content" heuristic returned whatever was newest, so a page listing a 2031 conference reported 2031 as its last-updated time at 70% confidence. Verified: that page now returns the real `2024-03-05` instead.
- **`url-normalizer.ts`** — `replace(/\s+/g, '')` ran before `new URL()`, deleting spaces inside the path and query rather than trimming the ends. `read_url("https://en.wikipedia.org/wiki/New York City")` — a very common LLM-emitted form — was fetched as `.../NewYorkCity` and the resulting 404 was attributed to the original URL. Now strips only C0 controls and lets `new URL()` percent-encode. Checked against 8 cases: only the two buggy ones change.
- **`token-guardrail.ts`** — if the first content item alone exceeded the budget, the packing loop `break`'d immediately and returned a response with **no text content at all**, silently. Now always keeps a truncated prefix, preserves the original item order (images used to be hoisted ahead of text), and appends a note saying what was cut.
- **`deduplicate_images`** — `selectedImage?.index || i` reported the wrong index whenever the real index was `0`; results were grouped URLs-then-base64 instead of selection order; the reverse lookup by URL string resolved duplicate URLs to the first occurrence; and every base64 input was labelled `image/jpeg` regardless of format.
- **`capture_screenshot_url`** — the default path requests a `pageshot` (full page, often 1280×20000) and piped it through a hardcoded 800×800 `scale-down` box, producing a ~51px-wide sliver with nothing legible. Width-constrained only for pageshots.
- **`search_images`** — returned `{content: []}` with no `isError` when every download failed, indistinguishable from "no images found". Also downloaded *every* URL the upstream returned; now bounded by a `num` parameter (default 10).
- **`search_bibtex`** — `author` was destructured out of the Semantic Scholar branch, so DBLP filtered by author and S2 did not. Non-2xx responses returned `[]`, so an S2 429 (routine when unauthenticated) looked like "no matches"; partial outages now surface as `warnings`. LaTeX escaping missed `\`, `{`, `}`, `~`, `^` and was never applied to the author field. Results were sorted year-descending *before* slicing, discarding both APIs' relevance ranking; now interleaved, trimmed, then sorted for display.
- **`show_api_key`** — echoed `props.bearerToken`, which is not necessarily the caller's own credential: `index.ts` substitutes the deployment's configured key when a request supplies none. Now gated on the token having actually arrived on the request. Worth rotating the configured key alongside this.
- **`handleApiError`** — never read the response body, so a 422 "input exceeds the maximum length" was indistinguishable from any other 422.

## Robustness

`AbortSignal` deadlines on every outbound fetch — previously nothing cancelled, so a hung upstream held the invocation open until the platform killed it, and abandoned requests kept their connections. Timers are always cleared.

Previously-unbounded inputs are now bounded: the array forms of `read_url` / `search_web` / `search_arxiv` / `search_ssrn` / `search_jina_blog` cap at 5, matching the `.max(5)` their `parallel_*` twins already had (the union forms made that guard bypassable); dedup/classify/rerank arrays are capped; `num` finally enforces the documented 1–100; page and feed bodies in `guess_datetime_url` are size-capped before ~15 regex passes run over them.

## Behaviour changes worth a look

1. **Guardrail becomes reachable.** Clients matching the existing allow-list will now actually get truncated responses. Any client can state its own budget with `?max_tokens=N` on the endpoint URL; `?max_tokens=0` opts out. Unknown clients are unaffected, as before.
2. **Citation keys change format** — `vaswani2017attention` rather than `attention2017`, with `a`/`b`/`c` de-collision. Needed to fix the silent dedup data loss.
3. **Input caps turn some previously-accepted calls into validation errors** (arrays over 5, `num` over 100).
4. **`lazyGreedySelectionWithSaturation` returns one fewer item** when the early stop fires — it was including the element whose marginal gain had *already* fallen below the threshold.

## Deliberately not in this PR

- `guess_datetime_url` and `search_bibtex` require no bearer token, so they act as unauthenticated outbound-fetch amplifiers. The fan-out is now bounded and cancellable, but whether to require auth is a product decision.
- Guardrail client detection still relies on the transport `User-Agent` as a fallback. Making it fully reliable means passing `storage` to `createMcpHandler` so `initializeParams` are replayed — that needs a binding and belongs in its own change.
- A full 21-tool server with all its zod schemas is constructed on every request, including for `/`, 404s and CORS preflights that never use it.
- There are no tests and no CI. The differential harnesses used to validate the submodular rewrite and the bibtex fixes were run ad hoc; they'd be worth landing as a suite.
