### PR TITLE
docs: use native Codex MCP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,14 @@ claude mcp add -s user --transport http jina https://mcp.jina.ai/v1 \
   --header "Authorization: Bearer ${JINA_API_KEY}"
 ```
 
-For OpenAI Codex: find `~/.codex/config.toml` and add the following:
+For OpenAI Codex: set `JINA_API_KEY` as an environment variable before starting Codex, then add the following to `~/.codex/config.toml`:
 ```toml
 [mcp_servers.jina-mcp-server]
-command = "npx"
-args = [
-    "-y",
-    "mcp-remote",
-    "https://mcp.jina.ai/v1",
-    "--header",
-    "Authorization: Bearer ${JINA_API_KEY}"]
+url = "https://mcp.jina.ai/v1"
+bearer_token_env_var = "JINA_API_KEY"
 ```
+
+This uses Codex's native Streamable HTTP support and keeps the API key out of the config file.
 
 ## Tool Filtering before Registering
 


### PR DESCRIPTION
## Summary
- replace the Codex `npx`/`mcp-remote` wrapper with native remote MCP configuration
- use the current Streamable HTTP endpoint and `bearer_token_env_var` so `JINA_API_KEY` stays outside `config.toml`

Fixes #13

## Validation
- `python3 -m pytest -q /tmp/test_jina_codex_readme.py`
- `npm run type-check`
- parsed the documented TOML and verified the expected Codex configuration
- `git diff --check`

## Scope
Documentation only; no API keys or runtime behavior are changed.